### PR TITLE
Per-entry formatting tags and fallback values

### DIFF
--- a/js/wp-seo.js
+++ b/js/wp-seo.js
@@ -30,10 +30,11 @@
 			var input = $( '#wp_seo_meta_' + field );
 			if ( input.length > 0 ) {
 				var matches = input.val().match( wp_seo_admin.formatting_tag_pattern );
+				var element = '.' + field + '-character-count';
 				if ( matches ) {
-					$( '.' + field + '-character-count' ).html( _.template( wp_seo_admin.estimated_count_text, { count: ( input.val().length - matches.join('').length ) } ) );
+					$( element ).html( _.template( wp_seo_admin.estimated_count_text, { count: ( input.val().length - matches.join('').length ) } ) );
 				} else {
-					$( '.' + field + '-character-count' ).html( input.val().length );
+					$( element ).html( input.val().length );
 				}
 			}
 		});

--- a/js/wp-seo.js
+++ b/js/wp-seo.js
@@ -20,15 +20,31 @@
 
 	/**
 	 * Update the description and title character counts displayed to the user.
+	 *
+	 * If a string has a formatting tag, uses Underscores to render a template
+	 * with an estimated character count. The estimate is the total string
+	 * length minus the length of the formatting tags.
 	 */
 	function wpseo_update_character_counts() {
 		_.each( ['title', 'description'], function( field ) {
 			var input = $( '#wp_seo_meta_' + field );
 			if ( input.length > 0 ) {
-				$( '.' + field + '-character-count' ).html( input.val().length );
+				var matches = input.val().match( wp_seo_admin.formatting_tag_pattern );
+				if ( matches ) {
+					$( '.' + field + '-character-count' ).html( _.template( wp_seo_admin.estimated_count_text, { count: ( input.val().length - matches.join('').length ) } ) );
+				} else {
+					$( '.' + field + '-character-count' ).html( input.val().length );
+				}
 			}
 		});
 	}
+
+	/**
+	 * Add the default formatting tag pattern to the localized object.
+	 *
+	 * @type {RegExp}
+	 */
+	window.wp_seo_admin.formatting_tag_pattern = /#[a-zA-Z\_]+#/g;
 
 	wpseo_update_character_counts();
 	$( '.wp-seo-post-meta-fields, .wp-seo-term-meta-fields' ).find( 'input, textarea' ).keyup( wpseo_update_character_counts );

--- a/js/wp-seo.js
+++ b/js/wp-seo.js
@@ -23,7 +23,7 @@
 	 *
 	 * If a string has a formatting tag, uses Underscores to render a template
 	 * with an estimated character count. The estimate is the total string
-	 * length minus the length of the formatting tags.
+	 * length minus the combined length of the formatting tags.
 	 */
 	function wpseo_update_character_counts() {
 		_.each( ['title', 'description'], function( field ) {

--- a/php/class-wp-seo.php
+++ b/php/class-wp-seo.php
@@ -366,6 +366,25 @@ class WP_SEO {
 			}
 		}
 
+		if ( count( $unique_matches ) !== count( $replacements ) ) {
+			foreach ( $unique_matches as $match ) {
+				if ( ! isset( $replacements[ $match ] ) ) {
+					/**
+					 * Filter the fallback value of formatting tags.
+					 *
+					 * This value is used when a formatting tag is encountered
+					 * in a string but no class for it was registered. For
+					 * example, it would be used if a tag is misspelled or if a
+					 * third-party plugin is deactivated.
+					 *
+					 * @param  string The fallback value. Defaults to empty string.
+					 * @param  string $match The found formatting tag.
+					 */
+					$replacements[ $match ] = apply_filters( 'wp_seo_format_fallback', '', $match );
+				}
+			}
+		}
+
 		if ( ! empty( $replacements ) ) {
 			$string = str_replace( array_keys( $replacements ), array_values( $replacements ), $string );
 		}

--- a/php/class-wp-seo.php
+++ b/php/class-wp-seo.php
@@ -369,8 +369,9 @@ class WP_SEO {
 			return $string;
 		}
 
-		$replacements = array();
 		$unique_matches = array_unique( $matches );
+		$replacements = array();
+		$unregistered = array();
 
 		// Loop through all tags here; wp_list_pluck() or similar would anyway.
 		foreach( $this->formatting_tags as $id => $tag ) {
@@ -403,9 +404,10 @@ class WP_SEO {
 					 * third-party plugin that provided the tag is deactivated.
 					 *
 					 * @param  string The fallback value. Defaults to empty string.
-					 * @param  string $match The found formatting tag.
+					 * @param  string $match The unregistered formatting tag.
 					 */
 					$replacements[ $match ] = apply_filters( 'wp_seo_format_fallback', '', $match );
+					$unregistered[] = $match;
 				}
 			}
 		}
@@ -417,10 +419,11 @@ class WP_SEO {
 		/**
 		 * Filter the formatted string.
 		 *
-		 * @param  string $string 		The formatted string.
+		 * @param  string $string       The formatted string.
 		 * @param  string $raw_string 	The string as submitted.
+		 * @param  array  $unregistered Array of any found, unregistered formatting tags.
 		 */
-		return apply_filters( 'wp_seo_after_format_string', $string, $raw_string );
+		return apply_filters( 'wp_seo_after_format_string', $string, $raw_string, $unregistered );
 	}
 
 	/**

--- a/php/class-wp-seo.php
+++ b/php/class-wp-seo.php
@@ -145,7 +145,7 @@ class WP_SEO {
 	 */
 	private function noscript_character_count( $text ) {
 		if ( false !== $matches = $this->get_formatting_tags( $text ) ) {
-			$message = sprintf( 'At least %d, depending on formatting tags', ( strlen( $text ) - strlen( implode( '', $matches ) ) ) );
+			$message = sprintf( __( 'At least %d, depending on formatting tags', 'wp-seo' ), ( strlen( $text ) - strlen( implode( '', $matches ) ) ) );
 		} else {
 			$message = strlen( $text );
 		}

--- a/php/class-wp-seo.php
+++ b/php/class-wp-seo.php
@@ -136,16 +136,15 @@ class WP_SEO {
 	/**
 	 * Helper to get the translated <noscript> text for the character count.
 	 *
-	 * @see  wp_seo_admin_scripts(), wpseo_update_character_counts() for the
-	 *     message and logic behind JS-enabled character count estimates when
-	 *     formatting tags are detected.
+	 * @see  wpseo_update_character_counts() for the logic behind JS-enabled
+	 *     character count estimates when formatting tags are detected.
 	 *
 	 * @param  string $text The text to count.
 	 * @return string The text to go between the <noscript> tags.
 	 */
 	private function noscript_character_count( $text ) {
 		if ( false !== $matches = $this->get_formatting_tags( $text ) ) {
-			$message = sprintf( __( 'At least %d, depending on formatting tags', 'wp-seo' ), ( strlen( $text ) - strlen( implode( '', $matches ) ) ) );
+			$message = sprintf( wp_seo_get_estimated_character_count_string( '%d' ), ( strlen( $text ) - strlen( implode( '', $matches ) ) ) );
 		} else {
 			$message = strlen( $text );
 		}

--- a/php/class-wp-seo.php
+++ b/php/class-wp-seo.php
@@ -375,7 +375,7 @@ class WP_SEO {
 					 * This value is used when a formatting tag is encountered
 					 * in a string but no class for it was registered. For
 					 * example, it would be used if a tag is misspelled or if a
-					 * third-party plugin is deactivated.
+					 * third-party plugin that provided the tag is deactivated.
 					 *
 					 * @param  string The fallback value. Defaults to empty string.
 					 * @param  string $match The found formatting tag.
@@ -411,7 +411,7 @@ class WP_SEO {
 	public function wp_title( $title, $sep ) {
 		if ( is_singular() ) {
 			if ( WP_SEO_Settings()->has_post_fields( $post_type = get_post_type() ) && $meta_title = get_post_meta( get_the_ID(), '_meta_title', true ) ) {
-				return $meta_title;
+				return $this->format( $meta_title );
 			} else {
 				$key = "single_{$post_type}_title";
 			}
@@ -421,7 +421,7 @@ class WP_SEO {
 			$key = 'archive_author_title';
 		} elseif ( is_category() || is_tag() || is_tax() ) {
 			if ( ( WP_SEO_Settings()->has_term_fields( $taxonomy = get_queried_object()->taxonomy ) ) && ( $option = get_option( $this->get_term_fields_option_name( get_queried_object() ) ) ) && ( ! empty( $option['title'] ) ) ) {
-				return $option['title'];
+				return $this->format( $option['title'] );
 			} else {
 				$key = "archive_{$taxonomy}_title";
 			}
@@ -510,12 +510,11 @@ class WP_SEO {
 				 * @param  string 		The format string retrieved from the settings.
 				 * @param  string $key	The key of the setting retrieved.
 				 */
-				$description_string = apply_filters( 'wp_seo_meta_description_format', WP_SEO_Settings()->get_option( "{$key}_description" ), $key );
-				$meta_description = $this->format( $description_string );
+				$meta_description = apply_filters( 'wp_seo_meta_description_format', WP_SEO_Settings()->get_option( "{$key}_description" ), $key );
 			}
 
 			if ( $meta_description ) {
-				$this->meta_field( 'description', $meta_description );
+				$this->meta_field( 'description', $this->format( $meta_description ) );
 			}
 
 			if ( empty( $meta_keywords ) ) {
@@ -525,12 +524,11 @@ class WP_SEO {
 				 * @param  string 		The format string retrieved from the settings.
 				 * @param  string $key	The key of the setting retrieved.
 				 */
-				$keywords_string = apply_filters( 'wp_seo_meta_keywords_format', WP_SEO_Settings()->get_option( "{$key}_keywords" ), $key );
-				$meta_keywords = $this->format( $keywords_string );
+				$meta_keywords = apply_filters( 'wp_seo_meta_keywords_format', WP_SEO_Settings()->get_option( "{$key}_keywords" ), $key );
 			}
 
 			if ( $meta_keywords ) {
-				$this->meta_field( 'keywords', $meta_keywords );
+				$this->meta_field( 'keywords', $this->format( $meta_keywords ) );
 			}
 		}
 
@@ -545,7 +543,7 @@ class WP_SEO {
 		 * }
 		 */
 		foreach( apply_filters( 'wp_seo_arbitrary_tags', WP_SEO_Settings()->get_option( 'arbitrary_tags' ) ) as $tag ) {
-			$this->meta_field( $tag['name'], $tag['content'] );
+			$this->meta_field( $tag['name'], $this->format( $tag['content'] ) );
 		}
 
 	}

--- a/wp-seo.php
+++ b/wp-seo.php
@@ -33,8 +33,9 @@ require_once WP_SEO_PATH . '/php/default-formatting-tags.php';
 function wp_seo_admin_scripts() {
 	wp_enqueue_script( 'wp-seo-admin', WP_SEO_URL . 'js/wp-seo.js', array( 'jquery', 'underscore' ), '0.9.0', true );
 	wp_localize_script( 'wp-seo-admin', 'wp_seo_admin', array(
-		'repeatable_add_more_label' => esc_html__( 'Add another', 'wp-seo' ),
-		'repeatable_remove_label' => esc_html__( 'Remove group', 'wp-seo' ),
+		'estimated_count_text' => __( 'At least <%= count %>, depending on formatting tags', 'wp-seo' ),
+		'repeatable_add_more_label' => __( 'Add another', 'wp-seo' ),
+		'repeatable_remove_label' => __( 'Remove group', 'wp-seo' ),
 	) );
 
 	wp_enqueue_style( 'wp-seo-admin', WP_SEO_URL . 'css/wp-seo.css', array(), '0.9.0' );

--- a/wp-seo.php
+++ b/wp-seo.php
@@ -33,7 +33,7 @@ require_once WP_SEO_PATH . '/php/default-formatting-tags.php';
 function wp_seo_admin_scripts() {
 	wp_enqueue_script( 'wp-seo-admin', WP_SEO_URL . 'js/wp-seo.js', array( 'jquery', 'underscore' ), '0.9.0', true );
 	wp_localize_script( 'wp-seo-admin', 'wp_seo_admin', array(
-		'estimated_count_text' => __( 'At least <%= count %>, depending on formatting tags', 'wp-seo' ),
+		'estimated_count_text' => wp_seo_get_estimated_character_count_string( '<%= count %>' ),
 		'repeatable_add_more_label' => __( 'Add another', 'wp-seo' ),
 		'repeatable_remove_label' => __( 'Remove group', 'wp-seo' ),
 	) );
@@ -41,3 +41,17 @@ function wp_seo_admin_scripts() {
 	wp_enqueue_style( 'wp-seo-admin', WP_SEO_URL . 'css/wp-seo.css', array(), '0.9.0' );
 }
 add_action( 'admin_enqueue_scripts', 'wp_seo_admin_scripts' );
+
+/**
+ * Get the string to use when field character counts are estimated.
+ *
+ * This allows for consistent text with per-language placeholders.
+ *
+ * @param string $placeholder The placeholder for the estimated character count.
+ *     PHP can pass "%d" to receive a printf()-friendly string; JavaScript can
+ *     pass "<%= count %>" for Underscores templates.
+ * @return string Translated string
+ */
+function wp_seo_get_estimated_character_count_string( $placeholder ) {
+	return sprintf( __( 'At least %s, depending on formatting tags', 'wp-seo' ), $placeholder );
+}


### PR DESCRIPTION
These changes allow formatting tags to appear in per-entry and per-term SEO fields. Per #4, they also add a fallback value (an empty string) for formatting tags found in a string but without a registered class.

As I was working on these changes, though, I had second thoughts about using an empty string as the fallback, and I hoped we could discuss it further before merging.

Here is what made me hesitant:

1. The default formatting tags also output an empty string when they don't have a value for the current page (e.g., `#author#` on a date archive). Using an empty string as the unregistered fallback could create confusion about whether a tag is broken or just doesn't have a value on the page.
2. We don't know why a formatting tag is unregistered. Maybe it's only a typo, in which case a blank string might cause users to think something is broken with the plugin or tag itself. Using something like the raw tag instead might tip them off.
3. We could harm the user experience if a tag goes missing. An example of the situation that sticks in my mind is a string like "All posts by #twitter_handle#." Without `#twitter_handle#`, the whole thing loses its value. If a user found that their site's titles were suddenly "All posts by", I worry that they would direct their anger at WP SEO, not whatever other plugin `#twitter_handle#` came from.

An alternative to a blank string is the current behavior of just the raw tag. The `wp_seo_format_fallback` filter added in this PR could still be applied to allow for customizations.

Another option is to bail on the entire field if an unregistered tag is found. This "safe mode" would have the most protection against nonsensical output, but it's also heavy-handed. ("Safe mode" could also be made available with a filter independently of the decision here, similar to the `wp_seo_use_settings_accordions` filter.)

And I'm sure there are other alternatives I haven't thought of yet.