### PR TITLE
Hook set_properties() after the default priority

### DIFF
--- a/php/class-wp-seo-settings.php
+++ b/php/class-wp-seo-settings.php
@@ -75,14 +75,14 @@ class WP_SEO_Settings {
 	 */
 	protected function setup() {
 		if ( is_admin() ) {
-			add_action( 'init', array( $this, 'set_properties' ) );
+			add_action( 'init', array( $this, 'set_properties' ), 20 );
 			add_action( 'admin_menu', array( $this, 'add_options_page' ) );
 			add_action( 'load-settings_page_' . $this::SLUG, array( $this, 'add_help_tab' ) );
 			add_action( 'admin_init', array( $this, 'register_settings' ) );
 		}
 
 		// Call after set_properties(), which sets the default options.
-		add_action( 'init', array( $this, 'load_options' ), 11 );
+		add_action( 'init', array( $this, 'load_options' ), 21 );
 	}
 
 	/**


### PR DESCRIPTION
Helps ensure taxonomies or post types registered on "init" at priority 10 are included.
