### PR TITLE
Use WP_SEO::format() on arbitrary tags

### DIFF
--- a/php/class-wp-seo.php
+++ b/php/class-wp-seo.php
@@ -569,7 +569,7 @@ class WP_SEO {
 		$arbitrary_tags = apply_filters( 'wp_seo_arbitrary_tags', WP_SEO_Settings()->get_option( 'arbitrary_tags' ) );
 		if ( is_array( $arbitrary_tags ) ) {
 			foreach ( $arbitrary_tags as $tag ) {
-				$this->meta_field( $tag['name'], $tag['content'] );
+				$this->meta_field( $tag['name'], $this->format( $tag['content'] ) );
 			}
 		}
 


### PR DESCRIPTION
This change provides consistency with the behavior of the meta fields on the rest of the settings page.

It also occurs as part of #12, but I don't think the result of the discussion occurring there would affect it.
