### PR TITLE
Begin breaking apart `WP_SEO`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+sudo: false
+
 php:
     - 5.3
     - 5.4

--- a/php/class-wp-seo-post-meta-boxes.php
+++ b/php/class-wp-seo-post-meta-boxes.php
@@ -143,7 +143,7 @@ class WP_SEO_Post_Meta_Boxes {
 						<td>
 							<input type="text" id="wp_seo_meta_title" name="seo_meta[title]" value="<?php echo esc_attr( $title ); ?>" size="96" />
 							<div>
-								<?php esc_html_e( 'Title character count: ', 'wp-seo' ); ?>
+								<?php esc_html_e( 'Title character count:', 'wp-seo' ); ?>
 								<span class="title-character-count"></span>
 								<noscript><?php echo esc_html( wp_seo_noscript_character_count( $title ) ); ?></noscript>
 							</div>
@@ -154,7 +154,7 @@ class WP_SEO_Post_Meta_Boxes {
 						<td>
 							<textarea id="wp_seo_meta_description" name="seo_meta[description]" rows="2" cols="96"><?php echo esc_textarea( $description ); ?></textarea>
 							<div>
-								<?php esc_html_e( 'Description character count: ', 'wp-seo' ); ?>
+								<?php esc_html_e( 'Description character count:', 'wp-seo' ); ?>
 								<span class="description-character-count"></span>
 								<noscript><?php echo esc_html( wp_seo_noscript_character_count( $description ) ); ?></noscript>
 							</div>

--- a/php/class-wp-seo-post-meta-boxes.php
+++ b/php/class-wp-seo-post-meta-boxes.php
@@ -1,0 +1,235 @@
+<?php
+/**
+ * Adds meta boxes to edit-post screens and saves the submitted data.
+ *
+ * @package WP_SEO
+ */
+class WP_SEO_Post_Meta_Boxes {
+
+	/**
+	 * Instance of this class.
+	 *
+	 * @var WP_SEO_Post_Meta_Boxes
+	 */
+	private static $instance = null;
+
+	/**
+	 * @codeCoverageIgnore
+	 */
+	private function __construct() {
+		/* Don't do anything, needs to be initialized via instance() method */
+	}
+
+	/**
+	 * Return an instance of this class.
+	 *
+	 * @codeCoverageIgnore
+	 *
+	 * @return WP_SEO_Post_Meta_Boxes
+	 */
+	public static function instance() {
+		if ( ! isset( self::$instance ) ) {
+			self::$instance = new self;
+			self::$instance->setup();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Add actions and filters.
+	 *
+	 * @codeCoverageIgnore
+	 */
+	protected function setup() {
+		add_action( 'add_meta_boxes', array( $this, 'add_meta_boxes' ), 10, 2 );
+		add_action( 'save_post', array( $this, 'save_post' ), 10, 3 );
+		add_action( 'edit_attachment', array( $this, 'edit_attachment' ) );
+		add_action( 'add_attachment', array( $this, 'add_attachment' ) );
+	}
+
+	/**
+	 * Fires after all built-in meta boxes have been added to an edit screen.
+	 *
+	 * @param string $post_type Post type.
+	 * @param WP_Post $post Post object.
+	 */
+	public function add_meta_boxes( $post_type, $post ) {
+		$this->register_meta_box( $post_type );
+	}
+
+	/**
+	 * Post meta box callback.
+	 *
+	 * @param WP_Post $post The post being edited.
+	 */
+	public function do_meta_box( $post ) {
+		$this->render_meta_box( $post );
+	}
+
+	/**
+	 * Fires once a post has been saved.
+	 *
+	 * @param int $post_ID Post ID.
+	 * @param WP_Post $post Post object.
+	 * @param bool $update Whether this is an existing post being updated.
+	 */
+	public function save_post( $post_ID, $post, $update ) {
+		$this->save_fields( $post_ID );
+	}
+
+	/**
+	 * Fires once an attachment has been added.
+	 *
+	 * @param int $post_ID Attachment ID.
+	 */
+	public function add_attachment( $post_ID ) {
+		$this->save_fields( $post_ID );
+	}
+
+	/**
+	 * Fires once an existing attachment has been updated.
+	 *
+	 * @param int $post_ID Attachment ID.
+	 */
+	public function edit_attachment( $post_ID ) {
+		$this->save_fields( $post_ID );
+	}
+
+	/**
+	 * Register a WP SEO post meta box.
+	 *
+	 * @param string $post_type Post type to register the meta box with.
+	 */
+	private function register_meta_box( $post_type ) {
+		if ( ! WP_SEO_Settings()->has_post_fields( $post_type ) ) {
+			return;
+		}
+
+		add_meta_box(
+			'wp_seo',
+			wp_seo_meta_box_heading(),
+			array( $this, 'do_meta_box' ),
+			$post_type,
+			/**
+			 * Filter the screen context where the fields should display.
+			 *
+			 * @param string @see add_meta_box().
+			 */
+			apply_filters( 'wp_seo_meta_box_context', 'normal' ),
+			/**
+			 * Filter the display priority of the fields within the context.
+			 *
+			 * @param string @see add_meta_box().
+			 */
+			apply_filters( 'wp_seo_meta_box_priority', 'high' )
+		);
+	}
+
+	/**
+	 * Display the SEO fields for a post.
+	 *
+	 * @param WP_Post $post The post being edited.
+	 */
+	private function render_meta_box( $post ) {
+		$title = get_post_meta( $post->ID, '_meta_title', true );
+		$description = get_post_meta( $post->ID, '_meta_description', true );
+		wp_nonce_field( plugin_basename( __FILE__ ), 'wp-seo-nonce' );
+		?>
+			<table class="wp-seo-post-meta-fields">
+				<tbody>
+					<tr>
+						<th scope="row"><label for="wp_seo_meta_title"><?php esc_html_e( 'Title Tag', 'wp-seo' ); ?></label></th>
+						<td>
+							<input type="text" id="wp_seo_meta_title" name="seo_meta[title]" value="<?php echo esc_attr( $title ); ?>" size="96" />
+							<div>
+								<?php esc_html_e( 'Title character count: ', 'wp-seo' ); ?>
+								<span class="title-character-count"></span>
+								<noscript><?php echo esc_html( wp_seo_noscript_character_count( $title ) ); ?></noscript>
+							</div>
+						</td>
+					</tr>
+					<tr>
+						<th scope="row"><label for="wp_seo_meta_description"><?php esc_html_e( 'Meta Description', 'wp-seo' ); ?></label></th>
+						<td>
+							<textarea id="wp_seo_meta_description" name="seo_meta[description]" rows="2" cols="96"><?php echo esc_textarea( $description ); ?></textarea>
+							<div>
+								<?php esc_html_e( 'Description character count: ', 'wp-seo' ); ?>
+								<span class="description-character-count"></span>
+								<noscript><?php echo esc_html( wp_seo_noscript_character_count( $description ) ); ?></noscript>
+							</div>
+						<td>
+					</tr>
+					<tr>
+						<th scope="row"><label for="wp_seo_meta_keywords"><?php esc_html_e( 'Meta Keywords', 'wp-seo' ) ?></label></th>
+						<td><textarea id="wp_seo_meta_keywords" name="seo_meta[keywords]" rows="2" cols="96"><?php echo esc_textarea( get_post_meta( $post->ID, '_meta_keywords', true ) ) ?></textarea></td>
+					</tr>
+				</tbody>
+			</table>
+		<?php
+	}
+
+	/**
+	 * Save the $_POST'ed SEO values as post meta.
+	 *
+	 * @param int $post_ID The post ID being edited.
+	 */
+	private function save_fields( $post_ID ) {
+		if ( ! isset( $_POST['post_type'] ) ) {
+			return;
+		}
+
+		$post_type = get_post_type_object( sanitize_text_field( $_POST['post_type'] ) );
+		if ( ! $post_type ) {
+			return;
+		}
+
+		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+			return;
+		}
+
+		if ( ! WP_SEO_Settings()->has_post_fields( $post_type->name ) ) {
+			return;
+		}
+
+		if ( empty( $post_type->cap->edit_post ) || ! current_user_can( $post_type->cap->edit_post, $post_ID ) ) {
+			return;
+		}
+
+		if ( ! isset( $_POST['wp-seo-nonce'] ) ) {
+			return;
+		}
+
+		if ( ! wp_verify_nonce( sanitize_text_field( $_POST['wp-seo-nonce'] ), plugin_basename( __FILE__ ) ) ) {
+			return;
+		}
+
+		if ( ! isset( $_POST['post_ID'] ) ) {
+			return;
+		}
+
+		$post_ID = absint( $_POST['post_ID'] );
+
+		if ( ! isset( $_POST['seo_meta'] ) ) {
+			$_POST['seo_meta'] = array();
+		}
+
+		foreach ( array( 'title', 'description', 'keywords' ) as $field ) {
+			$value = isset( $_POST['seo_meta'][ $field ] ) ? sanitize_text_field( $_POST['seo_meta'][ $field ] ) : '';
+			update_post_meta( $post_ID, "_meta_{$field}", $value );
+		}
+	}
+
+}
+
+/**
+ * Helper function to use the class instance.
+ *
+ * @todo destroy
+ *
+ * @return WP_SEO_Post_Meta_Boxes
+ */
+function wp_seo_post_meta_boxes() {
+	return WP_SEO_Post_Meta_Boxes::instance();
+}
+add_action( 'admin_init', 'wp_seo_post_meta_boxes' );

--- a/php/class-wp-seo-query.php
+++ b/php/class-wp-seo-query.php
@@ -1,0 +1,201 @@
+<?php
+/**
+ * Gets the WP SEO values for a WP_Query.
+ *
+ * @package WP_SEO
+ */
+class WP_SEO_Query {
+
+	/**
+	 * The {@see WP_Query} to get WP SEO values for.
+	 *
+	 * @var WP_Query
+	 */
+	private $wp_query;
+
+	/**
+	 * The prefix of the options array key with WP SEO values for the $wp_query.
+	 *
+	 * Includes the trailing underscore. e.g., `home_`.
+	 *
+	 * @var string
+	 */
+	private $key_prefix = '';
+
+	/**
+	 * The unformatted WP SEO title for the $wp_query.
+	 *
+	 * @var string
+	 */
+	private $title = '';
+
+	/**
+	 * The unformatted WP SEO description for the $wp_query.
+	 *
+	 * @var string
+	 */
+	private $description = '';
+
+	/**
+	 * The unformatted WP SEO keywords for the $wp_query.
+	 *
+	 * @var string
+	 */
+	private $keywords = '';
+
+	/**
+	 * Initialize the class.
+	 *
+	 * @param WP_Query $wp_query @see WP_SEO_Query::wp_query.
+	 */
+	function __construct( $wp_query ) {
+		if ( ! ( $wp_query instanceof WP_Query ) ) {
+			return;
+		}
+
+		$this->wp_query = $wp_query;
+		$this->init_key_prefix();
+		$this->init_values();
+	}
+
+	/**
+	 * Set $key_prefix based on this instance's $wp_query.
+	 */
+	private function init_key_prefix() {
+		switch ( true ) {
+			case $this->wp_query->is_singular() :
+				$post_type = get_post_type( $this->wp_query->get_queried_object() );
+				$this->key_prefix = "single_{$post_type}_";
+			break;
+
+			case $this->wp_query->is_front_page() :
+				$this->key_prefix = 'home_';
+			break;
+
+			case $this->wp_query->is_author() :
+				$this->key_prefix = 'archive_author_';
+			break;
+
+			case $this->wp_query->is_category() || $this->wp_query->is_tag() || $this->wp_query->is_tax() :
+				$taxonomy = $this->wp_query->get_queried_object()->taxonomy;
+				$this->key_prefix = "archive_{$taxonomy}_";
+			break;
+
+			case $this->wp_query->is_post_type_archive() :
+				$post_type = $this->wp_query->get_queried_object()->name;
+				$this->key_prefix = "archive_{$post_type}_";
+			break;
+
+			case $this->wp_query->is_date() :
+				$this->key_prefix = 'archive_date_';
+			break;
+
+			case $this->wp_query->is_search() :
+				$this->key_prefix = 'search_';
+			break;
+
+			case $this->wp_query->is_404() :
+				$this->key_prefix = '404_';
+			break;
+		}
+	}
+
+	/**
+	 * Set $title, $keywords, and $description based on the $wp_query and $key_prefix.
+	 */
+	private function init_values() {
+		if ( $this->wp_query->is_singular() ) {
+			$post_type = get_post_type( $this->wp_query->get_queried_object() );
+
+			if ( WP_SEO_Settings()->has_post_fields( $post_type ) ) {
+				$post_id = $this->wp_query->get_queried_object_id();
+
+				$meta_title = get_post_meta( $post_id, '_meta_title', true );
+				if ( $meta_title ) {
+					$this->title = $meta_title;
+				}
+
+				$meta_description = get_post_meta( $post_id, '_meta_description', true );
+				if ( $meta_description ) {
+					$this->description = $meta_description;
+				}
+
+				$meta_keywords = get_post_meta( $post_id, '_meta_keywords', true );
+				if ( $meta_keywords ) {
+					$this->keywords = $meta_keywords;
+				}
+			}
+		} elseif ( $this->wp_query->is_category() || $this->wp_query->is_tag() || $this->wp_query->is_tax() ) {
+			$option = get_option( wp_seo_get_term_option_name( $this->wp_query->get_queried_object() ) );
+
+			if ( ! empty( $option['title'] ) ) {
+				$this->title = $option['title'];
+			}
+
+			if ( ! empty( $option['description'] ) ) {
+				$this->description = $option['description'];
+			}
+
+			if ( ! empty( $option['keywords'] ) ) {
+				$this->keywords = $option['keywords'];
+			}
+		}
+
+		if ( $this->key_prefix ) {
+			if ( ! $this->title ) {
+				$this->title = WP_SEO_Settings()->get_option( $this->key_prefix . 'title' );
+			}
+
+			if ( ! $this->description ) {
+				$this->description = WP_SEO_Settings()->get_option( $this->key_prefix . 'description' );
+			}
+
+			if ( ! $this->keywords ) {
+				$this->keywords = WP_SEO_Settings()->get_option( $this->key_prefix . 'keywords' );
+			}
+		}
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function has_title() {
+		return ! empty( $this->title );
+	}
+
+	/**
+	 * @return string
+	 */
+	public function get_title() {
+		return $this->title;
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function has_description() {
+		return ! empty( $this->description );
+	}
+
+	/**
+	 * @return string
+	 */
+	public function get_description() {
+		return $this->description;
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function has_keywords() {
+		return ! empty( $this->keywords );
+	}
+
+	/**
+	 * @return string
+	 */
+	public function get_keywords() {
+		return $this->keywords;
+	}
+
+}

--- a/php/class-wp-seo-term-meta-boxes.php
+++ b/php/class-wp-seo-term-meta-boxes.php
@@ -1,0 +1,253 @@
+<?php
+/**
+ * Adds meta boxes to edit-term screens and saves the submitted data.
+ *
+ * @package WP_SEO
+ */
+class WP_SEO_Term_Meta_Boxes {
+
+	/**
+	 * Instance of this class.
+	 *
+	 * @var WP_SEO_Term_Meta_Boxes
+	 */
+	private static $instance = null;
+
+	/**
+	 * @codeCoverageIgnore
+	 */
+	private function __construct() {
+		/* Don't do anything, needs to be initialized via instance() method */
+	}
+
+	/**
+	 * Return an instance of this class.
+	 *
+	 * @codeCoverageIgnore
+	 *
+	 * @return WP_SEO_Term_Meta_Boxes
+	 */
+	public static function instance() {
+		if ( ! isset( self::$instance ) ) {
+			self::$instance = new self;
+			self::$instance->setup();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Add actions and filters.
+	 *
+	 * @codeCoverageIgnore
+	 */
+	protected function setup() {
+		$taxonomies = WP_SEO_Settings()->get_enabled_taxonomies();
+
+		if ( ! empty( $taxonomies ) ) {
+			foreach ( $taxonomies as $taxonomy ) {
+				add_action( "{$taxonomy}_add_form_fields", array( $this, 'taxonomy_add_form_fields' ) );
+				add_action( "{$taxonomy}_edit_form", array( $this, 'taxonomy_edit_form' ), 10, 2 );
+			}
+
+			add_action( 'created_term', array( $this, 'created_term' ), 10, 3 );
+			add_action( 'edited_term', array( $this, 'edited_term' ), 10, 3 );
+		}
+	}
+
+	/**
+	 * Fires after the Add Term form fields.
+	 *
+	 * @param string $taxonomy The taxonomy slug.
+	 */
+	public function taxonomy_add_form_fields( $taxonomy ) {
+		$this->render_add_term_fields();
+	}
+
+	/**
+	 * Fires at the end of the Edit Term form for all taxonomies.
+	 *
+	 * @param object $tag The term object
+	 * @param string $taxonomy The taxonomy slug
+	 */
+	public function taxonomy_edit_form( $tag, $taxonomy ) {
+		$this->render_edit_term_fields( $tag );
+	}
+
+	/**
+	 * Fires after a term is created, and the term cache has been cleaned.
+	 *
+	 * @param int $term_id Term ID.
+	 * @param int $term_taxonomy_id Term taxonomy ID.
+	 * @param string $taxonomy Taxonomy slug.
+	 */
+	public function created_term( $term_id, $term_taxonomy_id, $taxonomy ) {
+		$this->save_fields( $term_id, $taxonomy );
+	}
+
+	/**
+	 * Fires after a term is updated, and the term cache has been cleaned.
+	 *
+	 * @param int $term_id Term ID.
+	 * @param int $term_taxonomy_id Term taxonomy ID.
+	 * @param string $taxonomy Taxonomy slug.
+	 */
+	public function edited_term( $term_id, $term_taxonomy_id, $taxonomy ) {
+		$this->save_fields( $term_id, $taxonomy );
+	}
+
+	/**
+	 * Display the SEO fields, formatted for the Add Term screen.
+	 */
+	private function render_add_term_fields() {
+		wp_nonce_field( plugin_basename( __FILE__ ), 'wp-seo-nonce' );
+		?>
+			<h3><?php echo esc_html( wp_seo_meta_box_heading() ); ?></h3>
+
+			<div class="wp-seo-term-meta-fields">
+				<div class="form-field">
+					<label for="wp_seo_meta_title"><?php esc_html_e( 'Title Tag', 'wp-seo' ); ?></label>
+					<input type="text" id="wp_seo_meta_title" name="seo_meta[title]" value="" size="96" />
+					<p>
+						<?php esc_html_e( 'Title character count: ', 'wp-seo' ); ?>
+						<span class="title-character-count"></span>
+						<noscript><?php echo esc_html( wp_seo_noscript_character_count( '' ) ); ?></noscript>
+					</p>
+				</div>
+
+				<div class="form-field">
+					<label for="wp_seo_meta_description"><?php esc_html_e( 'Meta Description', 'wp-seo' ); ?></label>
+					<textarea id="wp_seo_meta_description" name="seo_meta[description]" rows="2" cols="96"></textarea>
+					<p>
+						<?php esc_html_e( 'Description character count: ', 'wp-seo' ); ?>
+						<span class="description-character-count"></span>
+						<noscript><?php echo esc_html( wp_seo_noscript_character_count( '' ) ); ?></noscript>
+					</p>
+				</div>
+
+				<div class="form-field">
+					<label for="wp_seo_meta_keywords"><?php esc_html_e( 'Meta Keywords', 'wp-seo' ) ?></label>
+					<textarea id="wp_seo_meta_keywords" name="seo_meta[keywords]" rows="2" cols="96"></textarea>
+				</div>
+			</div>
+		<?php
+	}
+
+	/**
+	 * Display the SEO fields, formatted for the Edit Term screen.
+	 *
+	 * @param object $term Term object.
+	 */
+	private function render_edit_term_fields( $term ) {
+		wp_nonce_field( plugin_basename( __FILE__ ), 'wp-seo-nonce' );
+
+		$values = get_option( wp_seo_get_term_option_name( $term ), array( 'title' => '', 'description' => '', 'keywords' => '' ) );
+		?>
+			<h2><?php echo esc_html( wp_seo_meta_box_heading() ); ?></h2>
+
+			<table class="form-table wp-seo-term-meta-fields">
+				<tbody>
+					<tr class="form-field">
+						<th scope="row"><label for="wp_seo_meta_title"><?php esc_html_e( 'Title Tag', 'wp-seo' ); ?></label></th>
+						<td>
+							<input type="text" id="wp_seo_meta_title" name="seo_meta[title]" value="<?php echo esc_attr( $values['title'] ); ?>" size="96" />
+							<p class="description">
+								<?php esc_html_e( 'Title character count: ', 'wp-seo' ); ?>
+								<span class="title-character-count"></span>
+								<noscript><?php echo esc_html( wp_seo_noscript_character_count( $values['title'] ) ); ?></noscript>
+							</p>
+						</td>
+					</tr>
+
+					<tr class="form-field">
+						<th scope="row"><label for="wp_seo_meta_description"><?php esc_html_e( 'Meta Description', 'wp-seo' ); ?></label></th>
+						<td>
+							<textarea id="wp_seo_meta_description" name="seo_meta[description]" rows="2" cols="96"><?php echo esc_textarea( $values['description'] ); ?></textarea>
+							<p class="description">
+								<?php esc_html_e( 'Description character count: ', 'wp-seo' ); ?>
+								<span class="description-character-count"></span>
+								<noscript><?php echo esc_html( wp_seo_noscript_character_count( $values['description'] ) ); ?></noscript>
+							</p>
+						<td>
+					</tr>
+
+					<tr class="form-field">
+						<th scope="row"><label for="wp_seo_meta_keywords"><?php esc_html_e( 'Meta Keywords', 'wp-seo' ) ?></label></th>
+						<td><textarea id="wp_seo_meta_keywords" name="seo_meta[keywords]" rows="2" cols="96"><?php echo esc_textarea( $values['keywords'] ); ?></textarea></td>
+					</tr>
+				</tbody>
+			</table>
+		<?php
+	}
+
+	/**
+	 * Save the SEO term values as an option.
+	 *
+	 * @see wp_unslash(), which the Settings API and update_post_meta() otherwise handle.
+	 *
+	 * @param int $term_id Term ID.
+	 * @param string $taxonomy Taxonomy slug.
+	 */
+	private function save_fields( $term_id, $taxonomy ) {
+		if ( ! isset( $_POST['taxonomy'] ) ) {
+			return;
+		}
+
+		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+			return;
+		}
+
+		if ( ! WP_SEO_Settings()->has_term_fields( $taxonomy ) ) {
+			return;
+		}
+
+		$taxonomy_object = get_taxonomy( $taxonomy );
+		if ( empty( $taxonomy_object->cap->edit_terms ) || ! current_user_can( $taxonomy_object->cap->edit_terms ) ) {
+			return;
+		}
+
+		if ( ! isset( $_POST['wp-seo-nonce'] ) ) {
+			return;
+		}
+
+		if ( ! wp_verify_nonce( sanitize_text_field( $_POST['wp-seo-nonce'] ), plugin_basename( __FILE__ ) ) ) {
+			return;
+		}
+
+		if ( ! isset( $_POST['seo_meta'] ) ) {
+			$_POST['seo_meta'] = array();
+		}
+
+		foreach ( array( 'title', 'description', 'keywords' ) as $field ) {
+			$data[ $field ] = isset( $_POST['seo_meta'][ $field ] ) ? sanitize_text_field( wp_unslash( $_POST['seo_meta'][ $field ] ) ) : '';
+		}
+
+		/**
+		 * @todo Check get_term(), add test.
+		 */
+		$name = wp_seo_get_term_option_name( get_term( $term_id, $taxonomy ) );
+
+		if ( false === get_option( $name ) ) {
+			// Don't create an option unless at least one field exists.
+			$filtered_data = array_filter( $data );
+			if ( ! empty( $filtered_data ) ) {
+				add_option( $name, $data, null, false );
+			}
+		} else {
+			update_option( $name, $data );
+		}
+	}
+
+}
+
+/**
+ * Helper function to use the class instance.
+ *
+ * @todo destroy
+ *
+ * @return object
+ */
+function wp_seo_term_meta_boxes() {
+	return WP_SEO_Term_Meta_Boxes::instance();
+}
+add_action( 'admin_init', 'wp_seo_term_meta_boxes' );

--- a/php/class-wp-seo-term-meta-boxes.php
+++ b/php/class-wp-seo-term-meta-boxes.php
@@ -109,7 +109,7 @@ class WP_SEO_Term_Meta_Boxes {
 					<label for="wp_seo_meta_title"><?php esc_html_e( 'Title Tag', 'wp-seo' ); ?></label>
 					<input type="text" id="wp_seo_meta_title" name="seo_meta[title]" value="" size="96" />
 					<p>
-						<?php esc_html_e( 'Title character count: ', 'wp-seo' ); ?>
+						<?php esc_html_e( 'Title character count:', 'wp-seo' ); ?>
 						<span class="title-character-count"></span>
 						<noscript><?php echo esc_html( wp_seo_noscript_character_count( '' ) ); ?></noscript>
 					</p>
@@ -119,7 +119,7 @@ class WP_SEO_Term_Meta_Boxes {
 					<label for="wp_seo_meta_description"><?php esc_html_e( 'Meta Description', 'wp-seo' ); ?></label>
 					<textarea id="wp_seo_meta_description" name="seo_meta[description]" rows="2" cols="96"></textarea>
 					<p>
-						<?php esc_html_e( 'Description character count: ', 'wp-seo' ); ?>
+						<?php esc_html_e( 'Description character count:', 'wp-seo' ); ?>
 						<span class="description-character-count"></span>
 						<noscript><?php echo esc_html( wp_seo_noscript_character_count( '' ) ); ?></noscript>
 					</p>
@@ -152,7 +152,7 @@ class WP_SEO_Term_Meta_Boxes {
 						<td>
 							<input type="text" id="wp_seo_meta_title" name="seo_meta[title]" value="<?php echo esc_attr( $values['title'] ); ?>" size="96" />
 							<p class="description">
-								<?php esc_html_e( 'Title character count: ', 'wp-seo' ); ?>
+								<?php esc_html_e( 'Title character count:', 'wp-seo' ); ?>
 								<span class="title-character-count"></span>
 								<noscript><?php echo esc_html( wp_seo_noscript_character_count( $values['title'] ) ); ?></noscript>
 							</p>
@@ -164,7 +164,7 @@ class WP_SEO_Term_Meta_Boxes {
 						<td>
 							<textarea id="wp_seo_meta_description" name="seo_meta[description]" rows="2" cols="96"><?php echo esc_textarea( $values['description'] ); ?></textarea>
 							<p class="description">
-								<?php esc_html_e( 'Description character count: ', 'wp-seo' ); ?>
+								<?php esc_html_e( 'Description character count:', 'wp-seo' ); ?>
 								<span class="description-character-count"></span>
 								<noscript><?php echo esc_html( wp_seo_noscript_character_count( $values['description'] ) ); ?></noscript>
 							</p>

--- a/php/class-wp-seo.php
+++ b/php/class-wp-seo.php
@@ -1,39 +1,31 @@
 <?php
-if ( ! class_exists( 'WP_SEO' ) ) :
 /**
- * WP SEO Core Functionality
+ * Sets the page title and renders meta fields.
  *
- * @package WP SEO
+ * @package WP_SEO
  */
 class WP_SEO {
 
 	/**
 	 * Instance of this class.
 	 *
-	 * @var object
+	 * @var WP_SEO
 	 */
 	private static $instance = null;
 
 	/**
-	 * Associative array of WP_SEO_Formatting_Tag instances.
+	 * Associative array of {@see WP_SEO_Formatting_Tag} IDs and instances.
 	 *
 	 * @var array.
 	 */
 	public $formatting_tags = array();
 
 	/**
-	 * The regular expression used to find formatting tags.
+	 * The regular expression used to find formatting tags in a string.
 	 *
 	 * @var string.
 	 */
 	public $formatting_tag_pattern = '';
-
-	/**
-	 * The heading text above the SEO fields on posts and terms.
-	 *
-	 * @var string
-	 */
-	private $box_heading = '';
 
 	/**
 	 * @codeCoverageIgnore
@@ -43,366 +35,60 @@ class WP_SEO {
 	}
 
 	/**
+	 * Return an instance of this class.
+	 *
 	 * @codeCoverageIgnore
-	 */
-	public function __clone() { wp_die( __( "Please don't __clone WP_SEO", "wp-seo" ) ); }
-
-	/**
-	 * @codeCoverageIgnore
-	 */
-	public function __wakeup() { wp_die( __( "Please don't __wakeup WP_SEO", "wp-seo" ) ); }
-
-	/**
-	 * @codeCoverageIgnore
+	 *
+	 * @return WP_SEO
 	 */
 	public static function instance() {
 		if ( ! isset( self::$instance ) ) {
-			self::$instance = new WP_SEO;
+			self::$instance = new self;
 			self::$instance->setup();
 		}
+
 		return self::$instance;
 	}
 
 	/**
-	 * Add actions and filters.
+	 * Initialize properties, add actions and filters.
 	 *
 	 * @codeCoverageIgnore
 	 */
 	protected function setup() {
-		add_action( 'wp_loaded', array( $this, 'set_properties' ) );
+		$this->init_formatting_tags();
+		$this->init_formatting_tag_pattern();
+		$this->init_seo_query();
 
-		if ( is_admin() ) {
-			add_action( 'add_meta_boxes', array( $this, 'add_meta_boxes' ) );
-			add_action( 'save_post', array( $this, 'save_post_fields' ) );
-			add_action( 'edit_attachment', array( $this, 'save_post_fields' ) );
-			add_action( 'add_attachment', array( $this, 'save_post_fields' ) );
-			add_action( 'admin_init', array( $this, 'add_term_boxes' ) );
-		}
-
-		add_filter( 'wp_title', array( $this, 'wp_title' ), 20, 2 );
-		add_filter( 'wp_head', array( $this, 'wp_head' ), 5 );
+		add_filter( 'wp_title', array( $this, 'filter_wp_title' ), 10, 3 );
+		add_action( 'wp_head', array( $this, 'wp_head' ) );
 	}
 
 	/**
-	 * Set class properties.
+	 * Filter the text of the page title.
 	 *
-	 * The filter for adding custom formatting tags is applied here.
+	 * @param string $title Page title.
+	 * @param string $sep Title separator.
+	 * @param string $seplocation Location of the separator (left or right).
+	 * @return string Page title, possibly updated.
 	 */
-	public function set_properties() {
-		$tags = array();
-		/**
-		 * Filter the available formatting tags.
-		 *
-		 * @see wp_seo_default_formatting_tags() for an example implementation.
-		 *
-		 * @param array $tags Associative array of WP_SEO_Formatting_Tag instances.
-		 */
-		foreach ( apply_filters( 'wp_seo_formatting_tags', $tags ) as $id => $tag ) {
-			if ( is_a( $tag, 'WP_SEO_Formatting_Tag' ) ) {
-				$tags[ $id ] = $tag;
-			}
+	public function filter_wp_title( $title, $sep, $seplocation ) {
+		$custom = $this->get_page_title();
+
+		if ( $custom ) {
+			$title = $custom;
 		}
-		$this->formatting_tags = $tags;
 
-		/**
-		 * Filter the regular expression used to find formatting tags.
-		 *
-		 * You might need this if you want to add unusual custom tags.
-		 *
-		 * @param string WP_SEO::formatting_tag_pattern The regex.
-		 */
-		$this->formatting_tag_pattern = apply_filters( 'wp_seo_formatting_tag_pattern', '/#[a-zA-Z\_]+#/' );
-
-		/**
-		 * Filter the heading above SEO fields on post- and term-edit screens.
-		 *
-		 * @param string The text.
-		 */
-		$this->box_heading = apply_filters( 'wp_seo_box_heading', __( 'Search Engine Optimization', 'wp-seo' ) );
+		return $title;
 	}
 
 	/**
-	 * Add the SEO fields to post types that support them.
-	 *
-	 * @param string $post_type The current post type.
+	 * Fires to print scripts or data in the head tag.
 	 */
-	public function add_meta_boxes( $post_type ) {
-		if ( WP_SEO_Settings()->has_post_fields( $post_type ) ) {
-			add_meta_box(
-				'wp_seo',
-				$this->box_heading,
-				array( $this, 'post_meta_fields' ),
-				$post_type,
-				/**
-				 * Filter the screen context where the fields should display.
-				 *
-				 * @param  string @see add_meta_box().
-				 */
-				apply_filters( 'wp_seo_meta_box_context', 'normal' ),
-				/**
-				 * Filter the display priority of the fields within the context.
-				 *
-				 * @param  string @see add_meta_box().
-				 */
-				apply_filters( 'wp_seo_meta_box_priority', 'high' )
-			);
-		}
-	}
-
-	/**
-	 * Helper to get the translated <noscript> text for the character count.
-	 *
-	 * @param  string $text The text to count.
-	 * @return string The text to go between the <noscript> tags.
-	 */
-	private function noscript_character_count( $text ) {
-		return sprintf( __( '%d (save changes to update)', 'wp-seo' ), strlen( $text ) );
-	}
-
-	/**
-	 * Display the SEO fields for a post.
-	 *
-	 * @param  WP_Post $post The post being edited.
-	 */
-	public function post_meta_fields( $post ) {
-		wp_nonce_field( plugin_basename( __FILE__ ), 'wp-seo-nonce' );
-		?>
-			<table class="wp-seo-post-meta-fields">
-				<tbody>
-					<tr>
-						<th scope="row"><label for="wp_seo_meta_title"><?php esc_html_e( 'Title Tag', 'wp-seo' ); ?></label></th>
-						<td>
-							<input type="text" id="wp_seo_meta_title" name="seo_meta[title]" value="<?php echo esc_attr( $title = get_post_meta( $post->ID, '_meta_title', true ) ); ?>" size="96" />
-							<div>
-								<?php esc_html_e( 'Title character count: ', 'wp-seo' ); ?>
-								<span class="title-character-count"></span>
-								<noscript><?php echo esc_html( $this->noscript_character_count( $title ) ); ?></noscript>
-							</div>
-						</td>
-					</tr>
-					<tr>
-						<th scope="row"><label for="wp_seo_meta_description"><?php esc_html_e( 'Meta Description', 'wp-seo' ); ?></label></th>
-						<td>
-							<textarea id="wp_seo_meta_description" name="seo_meta[description]" rows="2" cols="96"><?php echo esc_textarea( $description = get_post_meta( $post->ID, '_meta_description', true ) ); ?></textarea>
-							<div>
-								<?php esc_html_e( 'Description character count: ', 'wp-seo' ); ?>
-								<span class="description-character-count"></span>
-								<noscript><?php echo esc_html( $this->noscript_character_count( $description ) ); ?></noscript>
-							</div>
-						<td>
-					</tr>
-					<tr>
-						<th scope="row"><label for="wp_seo_meta_keywords"><?php esc_html_e( 'Meta Keywords', 'wp-seo' ) ?></label></th>
-						<td><textarea id="wp_seo_meta_keywords" name="seo_meta[keywords]" rows="2" cols="96"><?php echo esc_textarea( get_post_meta( $post->ID, '_meta_keywords', true ) ) ?></textarea></td>
-					</tr>
-				</tbody>
-			</table>
-		<?php
-	}
-
-	/**
-	 * Save the SEO values as post meta.
-	 *
-	 * @param  int $post_id The post ID being edited.
-	 */
-	public function save_post_fields( $post_id ) {
-		if ( ! isset( $_POST['post_type'] ) ) {
-			return;
-		}
-
-		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
-			return;
-		}
-
-		if ( ! WP_SEO_Settings()->has_post_fields( $_POST['post_type'] ) ) {
-			return;
-		}
-
-		$post_type = get_post_type_object( $_POST['post_type'] );
-		if ( empty( $post_type->cap->edit_post ) || ! current_user_can( $post_type->cap->edit_post, $post_id ) ) {
-			return;
-		}
-
-		if ( ! isset( $_POST['wp-seo-nonce'] ) ) {
-			return;
-		}
-
-		if ( ! wp_verify_nonce( $_POST['wp-seo-nonce'], plugin_basename( __FILE__ ) ) ) {
-			return;
-		}
-
-		if ( ! isset( $_POST['post_ID'] ) ) {
-			return;
-		}
-
-		$post_id = absint( $_POST['post_ID'] );
-
-		if ( ! isset( $_POST['seo_meta'] ) ) {
-			$_POST['seo_meta'] = array();
-		}
-
-		foreach ( array( 'title', 'description', 'keywords' ) as $field ) {
-			$data = isset( $_POST['seo_meta'][ $field ] ) ? sanitize_text_field( $_POST['seo_meta'][ $field ] ) : '';
-			update_post_meta( $post_id, '_meta_' . $field, $data );
-		}
-	}
-
-	/**
-	 * Add the meta box to taxonomies with per-term fields enabled.
-	 */
-	public function add_term_boxes() {
-		foreach ( WP_SEO_Settings()->get_enabled_taxonomies() as $slug ) {
-			add_action( $slug . '_add_form_fields', array( $this, 'add_term_meta_fields' ), 10, 2 );
-			add_action( $slug . '_edit_form', array( $this, 'edit_term_meta_fields' ), 10, 2 );
-		}
-		add_action( 'created_term', array( $this, 'save_term_fields' ), 10, 3 );
-		add_action( 'edited_term', array( $this, 'save_term_fields' ), 10, 3 );
-	}
-
-	/**
-	 * Helper to construct an option name for per-term SEO fields.
-	 *
-	 * @param  object $term The term object
-	 * @return string The option name
-	 */
-	public function get_term_option_name( $term ) {
-		return "wp-seo-term-{$term->term_taxonomy_id}";
-	}
-
-	/**
-	 * Display the SEO fields for adding a term.
-	 *
-	 * @param string $taxonomy The taxonomy slug.
-	 */
-	public function add_term_meta_fields( $taxonomy ) {
-		wp_nonce_field( plugin_basename( __FILE__ ), 'wp-seo-nonce' );
-		?>
-			<h3><?php echo esc_html( $this->box_heading ); ?></h3>
-			<div class="wp-seo-term-meta-fields">
-				<div class="form-field">
-					<label for="wp_seo_meta_title"><?php esc_html_e( 'Title Tag', 'wp-seo' ); ?></label>
-					<input type="text" id="wp_seo_meta_title" name="seo_meta[title]" value="" size="96" />
-					<p>
-						<?php esc_html_e( 'Title character count: ', 'wp-seo' ); ?>
-						<span class="title-character-count"></span>
-						<noscript><?php echo esc_html( $this->noscript_character_count( '' ) ); ?></noscript>
-					</p>
-				</div>
-				<div class="form-field">
-					<label for="wp_seo_meta_description"><?php esc_html_e( 'Meta Description', 'wp-seo' ); ?></label>
-					<textarea id="wp_seo_meta_description" name="seo_meta[description]" rows="2" cols="96"></textarea>
-					<p>
-						<?php esc_html_e( 'Description character count: ', 'wp-seo' ); ?>
-						<span class="description-character-count"></span>
-						<noscript><?php echo esc_html( $this->noscript_character_count( '' ) ); ?></noscript>
-					</p>
-				</div>
-				<div class="form-field">
-					<label for="wp_seo_meta_keywords"><?php esc_html_e( 'Meta Keywords', 'wp-seo' ) ?></label>
-					<textarea id="wp_seo_meta_keywords" name="seo_meta[keywords]" rows="2" cols="96"></textarea>
-				</div>
-			</div>
-		<?php
-	}
-
-	/**
-	 * Display the SEO fields for editing a term.
-	 *
-	 * @param  object $tag The term object
-	 * @param  string $taxonomy The taxonomy slug
-	 */
-	public function edit_term_meta_fields( $tag, $taxonomy ) {
-		$values = get_option( $this->get_term_option_name( $tag ), array( 'title' => '', 'description' => '', 'keywords' => '' ) );
-		wp_nonce_field( plugin_basename( __FILE__ ), 'wp-seo-nonce' );
-		?>
-			<h2><?php echo esc_html( $this->box_heading ); ?></h2>
-			<table class="form-table wp-seo-term-meta-fields">
-				<tbody>
-					<tr class="form-field">
-						<th scope="row"><label for="wp_seo_meta_title"><?php esc_html_e( 'Title Tag', 'wp-seo' ); ?></label></th>
-						<td>
-							<input type="text" id="wp_seo_meta_title" name="seo_meta[title]" value="<?php echo esc_attr( $title = $values['title'] ); ?>" size="96" />
-							<p class="description">
-								<?php esc_html_e( 'Title character count: ', 'wp-seo' ); ?>
-								<span class="title-character-count"></span>
-								<noscript><?php echo esc_html( $this->noscript_character_count( $title ) ); ?></noscript>
-							</p>
-						</td>
-					</tr>
-					<tr class="form-field">
-						<th scope="row"><label for="wp_seo_meta_description"><?php esc_html_e( 'Meta Description', 'wp-seo' ); ?></label></th>
-						<td>
-							<textarea id="wp_seo_meta_description" name="seo_meta[description]" rows="2" cols="96"><?php echo esc_textarea( $description = $values['description'] ); ?></textarea>
-							<p class="description">
-								<?php esc_html_e( 'Description character count: ', 'wp-seo' ); ?>
-								<span class="description-character-count"></span>
-								<noscript><?php echo esc_html( $this->noscript_character_count( $description ) ); ?></noscript>
-							</p>
-						<td>
-					</tr>
-					<tr class="form-field">
-						<th scope="row"><label for="wp_seo_meta_keywords"><?php esc_html_e( 'Meta Keywords', 'wp-seo' ) ?></label></th>
-						<td><textarea id="wp_seo_meta_keywords" name="seo_meta[keywords]" rows="2" cols="96"><?php echo esc_textarea( $values['keywords'] ); ?></textarea></td>
-					</tr>
-				</tbody>
-			</table>
-		<?php
-	}
-
-	/**
-	 * Save the SEO term values as an option.
-	 *
-	 * @see wp_unslash(), which the Settings API and update_post_meta()
-	 *     otherwise handle.
-	 *
-	 * @param  int $term_id Term ID.
-	 * @param  int $tt_id Term taxonomy ID.
-	 * @param  string $taxonomy Taxonomy slug.
-	 */
-	public function save_term_fields( $term_id, $tt_id, $taxonomy ) {
-		if ( ! isset( $_POST['taxonomy'] ) ) {
-			return;
-		}
-
-		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
-			return;
-		}
-
-		if ( ! WP_SEO_Settings()->has_term_fields( $taxonomy ) ) {
-			return;
-		}
-
-		$object = get_taxonomy( $taxonomy );
-		if ( empty( $object->cap->edit_terms ) || ! current_user_can( $object->cap->edit_terms ) ) {
-			return;
-		}
-
-		if ( ! isset( $_POST['wp-seo-nonce'] ) ) {
-			return;
-		}
-
-		if ( ! wp_verify_nonce( $_POST['wp-seo-nonce'], plugin_basename( __FILE__ ) ) ) {
-			return;
-		}
-
-		if ( ! isset( $_POST['seo_meta'] ) ) {
-			$_POST['seo_meta'] = array();
-		}
-
-		foreach ( array( 'title', 'description', 'keywords' ) as $field ) {
-			$data[ $field ] = isset( $_POST['seo_meta'][ $field ] ) ? sanitize_text_field( wp_unslash( $_POST['seo_meta'][ $field ] ) ) : '';
-		}
-
-		$name = $this->get_term_option_name( get_term( $term_id, $taxonomy ) );
-		if ( false === get_option( $name ) ) {
-			// Don't create an option unless at least one field exists.
-			$filtered_data = array_filter( $data );
-			if ( ! empty( $filtered_data ) ) {
-				add_option( $name, $data, null, false );
-			}
-		} else {
-			update_option( $name, $data );
-		}
+	public function wp_head() {
+		$this->render_meta_description();
+		$this->render_meta_keywords();
+		$this->render_arbitrary_tags();
 	}
 
 	/**
@@ -426,19 +112,19 @@ class WP_SEO {
 		$replacements = array();
 		$unique_matches = array_unique( $matches[0] );
 
-		foreach( $this->formatting_tags as $id => $tag ) {
+		foreach ( $this->formatting_tags as $id => $tag ) {
 			if ( ! empty( $tag->tag ) && in_array( $tag->tag, $unique_matches ) ) {
 				/**
 				 * Filter the value of a formatting tag for the current page.
 				 *
-				 * The dynamic portion of the hook name, $id, refers to the key
-				 * used to register the tag in WP_SEO::set_properties(). For
-				 * example, the hook for the default "#site_name#" formatting
-				 * tag is 'wp_seo_format_site_name'.
+				 * The dynamic portion of the hook name, `$id`, refers to the
+				 * key used to register the formatting tag. For example, the
+				 * hook for the default "#site_name#" formatting tag is
+				 * 'wp_seo_format_site_name'.
 				 *
 				 * @see wp_seo_default_formatting_tags() for the defaults' keys.
 				 *
-				 * @param  string The value returned by the formatting tag.
+				 * @param string The value returned by the formatting tag.
 				 */
 				$replacements[ $tag->tag ] = apply_filters( "wp_seo_format_{$id}", $tag->get_value() );
 			}
@@ -451,169 +137,249 @@ class WP_SEO {
 		/**
 		 * Filter the formatted string.
 		 *
-		 * @param  string $string 		The formatted string.
-		 * @param  string $raw_string 	The string as submitted.
+		 * @param string $string The formatted string.
+		 * @param string $raw_string The string as submitted.
 		 */
 		return apply_filters( 'wp_seo_after_format_string', $string, $raw_string );
 	}
 
 	/**
-	 * Filter the page title with the custom title or formatted title.
-	 *
-	 * @param  string $title The page title from wp_title().
-	 * @param  string $sep   The title separator.
-	 * @return string        The custom title of the current entry, if one
-	 *                       exists, or the formatted title from the settings
-	 *                       for the current post type. The original title if no
-	 *                       custom or formatted title exists.
+	 * Set the available formatting tags.
 	 */
-	public function wp_title( $title, $sep ) {
-		if ( is_singular() ) {
-			if ( WP_SEO_Settings()->has_post_fields( $post_type = get_post_type() ) && $meta_title = get_post_meta( get_the_ID(), '_meta_title', true ) ) {
-				return $meta_title;
-			} else {
-				$key = "single_{$post_type}_title";
-			}
-		} elseif ( is_front_page() ) {
-			$key = 'home_title';
-		} elseif ( is_author() ) {
-			$key = 'archive_author_title';
-		} elseif ( is_category() || is_tag() || is_tax() ) {
-			if ( ( WP_SEO_Settings()->has_term_fields( $taxonomy = get_queried_object()->taxonomy ) ) && ( $option = get_option( $this->get_term_option_name( get_queried_object() ) ) ) && ( ! empty( $option['title'] ) ) ) {
-				return $option['title'];
-			} else {
-				$key = "archive_{$taxonomy}_title";
-			}
-		} elseif ( is_post_type_archive() ) {
-			$key = 'archive_' . get_queried_object()->name . '_title';
-		} elseif ( is_date() ) {
-			$key = 'archive_date_title';
-		} elseif ( is_search() ) {
-			$key = 'search_title';
-		} elseif ( is_404() ) {
-			$key = '404_title';
-		} else {
-			$key = false;
-		}
+	private function init_formatting_tags() {
+		/**
+		 * Filter the available formatting tags.
+		 *
+		 * @see wp_seo_default_formatting_tags() for an example implementation.
+		 *
+		 * @param array $tags Associative array of WP_SEO_Formatting_Tag instances.
+		 */
+		$tags = apply_filters( 'wp_seo_formatting_tags', array() );
 
-		if ( $key ) {
-			/**
-			 * Filter the format string of the title tag for the current page.
-			 *
-			 * @param  string		The format string retrieved from the settings.
-			 * @param  string $key 	The key of the setting retrieved.
-			 */
-			$title_string = apply_filters( 'wp_seo_title_tag_format', WP_SEO_Settings()->get_option( $key ), $key );
-			$title_tag = $this->format( $title_string );
-			if ( $title_tag && ! is_wp_error( $title_tag ) ) {
-				$title = $title_tag;
+		foreach ( $tags as $id => $tag ) {
+			if ( $tag instanceof WP_SEO_Formatting_Tag ) {
+				$this->formatting_tags[ $id ] = $tag;
 			}
+		}
+	}
+
+	/**
+	 * Set the regular expression used to find formatting tags in a string.
+	 */
+	private function init_formatting_tag_pattern() {
+		/**
+		 * Filter the regular expression used to find formatting tags in a string.
+		 *
+		 * You might filter this if you want to add unusual custom tags.
+		 *
+		 * @param string $formatting_tag_pattern The regex.
+		 */
+		$this->formatting_tag_pattern = apply_filters( 'wp_seo_formatting_tag_pattern', '/#[a-zA-Z\_]+#/' );
+	}
+
+	/**
+	 * Set the {@see WP_SEO_Query} instance to use for this page.
+	 */
+	private function init_seo_query() {
+		global $wp_the_query;
+		$this->seo_query = new WP_SEO_Query( $wp_the_query );
+	}
+
+	/**
+	 * Get the custom page title for the current page.
+	 *
+	 * @return string The page title, if any.
+	 */
+	private function get_page_title() {
+		$title = $this->seo_query->get_title();
+
+		/**
+		 * Filter the WP SEO page title before replacing formatting tags.
+		 *
+		 * @todo Restore $key parameter?
+		 *
+		 * @param string $title The unformatted WP SEO page title.
+		 */
+		$title = apply_filters( 'wp_seo_title_tag_format', $title );
+
+		$title = $this->format( $title );
+
+		if ( is_wp_error( $title ) ) {
+			$title = '';
 		}
 
 		return $title;
 	}
 
 	/**
+	 * Render the meta description for the current page.
+	 */
+	private function render_meta_description() {
+		$description = $this->seo_query->get_description();
+
+		/**
+		 * Filter the WP SEO meta description before replacing formatting tags.
+		 *
+		 * @todo Restore $key?
+		 *
+		 * @param string $description The unformatted WP SEO meta description.
+		 */
+		$description = apply_filters( 'wp_seo_meta_description_format', $description );
+
+		$description = $this->format( $description );
+
+		if ( ! $description || is_wp_error( $description ) ) {
+			return;
+		}
+
+		$this->meta_field( 'description', $description );
+	}
+
+	/**
+	 * Render the meta keywords for the current page.
+	 */
+	private function render_meta_keywords() {
+		$keywords = $this->seo_query->get_keywords();
+
+		/**
+		 * Filter the WP SEO meta keywords before replacing formatting tags.
+		 *
+		 * @todo Restore $key?
+		 *
+		 * @param string $keywords The unformatted WP SEO meta keywords.
+		 */
+		$keywords = apply_filters( 'wp_seo_meta_keywords_format', $keywords );
+
+		$keywords = $this->format( $keywords );
+
+		if ( ! $keywords || is_wp_error( $keywords ) ) {
+			return;
+		}
+
+		$this->meta_field( 'keywords', $keywords );
+	}
+
+	/**
+	 * Render the arbitrary meta tags for the current page.
+	 */
+	private function render_arbitrary_tags() {
+		/**
+		 * @todo Safe get_option(), no type casting.
+		 */
+		$arbitrary_tags = (array) WP_SEO_Settings()->get_option( 'arbitrary_tags' );
+
+		/**
+		 * Filter the arbitrary meta tags for the current page.
+		 *
+		 * @param array $arbitrary_tags {
+		 *     Arrays of meta tag data.
+		 *
+		 *     @type array {
+		 *         @type string $name Tag "name" attribute.
+		 *         @type string $content Unformatted tag "content" attribute.
+		 *     }
+		 * }
+		 */
+		$arbitrary_tags = apply_filters( 'wp_seo_arbitrary_tags', $arbitrary_tags );
+
+		foreach ( $arbitrary_tags as $tag ) {
+			if ( empty( $tag['name'] ) || empty( $tag['content'] ) ) {
+				continue;
+			}
+
+			$content = $this->format( $tag['content'] );
+
+			if ( ! $content || is_wp_error( $content ) ) {
+				continue;
+			}
+
+			$this->meta_field( $tag['name'], $content );
+		}
+	}
+
+	/**
 	 * Render a <meta /> field.
 	 *
-	 * @access private.
-	 *
-	 * @param  string $name  The content of the "name" attribute.
-	 * @param  string $content The content of the "content" attribute.
+	 * @param string $name The "name" attribute.
+	 * @param string $content The "content" attribute.
 	 */
 	private function meta_field( $name, $content ) {
 		echo "<meta name='" . esc_attr( $name ) . "' content='" . esc_attr( $content ) . "' />\n";
 	}
 
 	/**
-	 * Determine the <meta> values for the current page.
-	 *
-	 * Unlike WP_SEO::wp_title(), custom per-entry and per-term values are not
-	 * returned immediately but rendered at the end of the method.
-	 *
-	 * @see WP_SEO::meta_field() for detail on how the values are rendered.
+	 * @deprecated
 	 */
-	public function wp_head() {
-		if ( is_singular() ) {
-			if ( WP_SEO_Settings()->has_post_fields( $post_type = get_post_type() ) ) {
-				$meta_description = get_post_meta( get_the_ID(), '_meta_description', true );
-				$meta_keywords = get_post_meta( get_the_ID(), '_meta_keywords', true );
-			}
-			$key = "single_{$post_type}";
-		} elseif ( is_front_page() ) {
-			$key = 'home';
-		} elseif ( is_author() ) {
-			$key = 'archive_author';
-		} elseif ( is_category() || is_tag() || is_tax() ) {
-			if ( WP_SEO_Settings()->has_term_fields( $taxonomy = get_queried_object()->taxonomy ) && $option = get_option( $this->get_term_option_name( get_queried_object() ) ) ) {
-				$meta_description = $option['description'];
-				$meta_keywords = $option['keywords'];
-			}
-			$key = "archive_{$taxonomy}";
-		} elseif ( is_post_type_archive() ) {
-			$key = 'archive_' . get_queried_object()->name;
-		} elseif ( is_date() ) {
-			$key = 'archive_date';
-		} else {
-			$key = false;
-		}
+	public function set_properties() {
+		_deprecated_function( __FUNCTION__, '1.0' );
+	}
 
-		if ( $key ) {
-			if ( empty( $meta_description ) ) {
-				/**
-				 * Filter the format string of the meta description for this page.
-				 *
-				 * @param  string 		The format string retrieved from the settings.
-				 * @param  string $key	The key of the setting retrieved.
-				 */
-				$description_string = apply_filters( 'wp_seo_meta_description_format', WP_SEO_Settings()->get_option( "{$key}_description" ), $key );
-				$meta_description = $this->format( $description_string );
-			}
+	/**
+	 * @deprecated
+	 */
+	public function add_meta_boxes( $post_type ) {
+		_deprecated_function( __FUNCTION__, '1.0', 'WP_SEO_Post_Meta_Boxes::add_meta_boxes()' );
+		WP_SEO_Post_Meta_Boxes::instance()->add_meta_boxes( $post_type, get_post() );
+	}
 
-			if ( $meta_description && ! is_wp_error( $meta_description ) ) {
-				$this->meta_field( 'description', $meta_description );
-			}
+	/**
+	 * @deprecated
+	 */
+	public function post_meta_fields( $post ) {
+		_deprecated_function( __FUNCTION__, '1.0', 'WP_SEO_Post_Meta_Boxes::do_meta_box()' );
+		WP_SEO_Post_Meta_Boxes::instance()->do_meta_box( $post );
+	}
 
-			if ( empty( $meta_keywords ) ) {
-				/**
-				 * Filter the format string of the meta keywords for this page.
-				 *
-				 * @param  string 		The format string retrieved from the settings.
-				 * @param  string $key	The key of the setting retrieved.
-				 */
-				$keywords_string = apply_filters( 'wp_seo_meta_keywords_format', WP_SEO_Settings()->get_option( "{$key}_keywords" ), $key );
-				$meta_keywords = $this->format( $keywords_string );
-			}
+	/**
+	 * @deprecated
+	 */
+	public function save_post_fields( $post_id ) {
+		_deprecated_function( __FUNCTION__, '1.0' );
+	}
 
-			if ( $meta_keywords && ! is_wp_error( $meta_keywords ) ) {
-				$this->meta_field( 'keywords', $meta_keywords );
-			}
-		}
+	/**
+	 * @deprecated
+	 */
+	public function add_term_boxes() {
+		_deprecated_function( __FUNCTION__, '1.0', 'WP_SEO_Term_Meta_Boxes::instance()' );
+		WP_SEO_Term_Meta_Boxes::instance();
+	}
 
-		/**
-		 * Filter the artibrary meta tags that display on this page.
-		 *
-		 * @param  array {
-		 *     Meta tag data.
-		 *
-		 *     @type  string $name    The field "name" attribute.
-		 *     @type  string $content The field "content" attribute.
-		 * }
-		 */
-		$arbitrary_tags = apply_filters( 'wp_seo_arbitrary_tags', WP_SEO_Settings()->get_option( 'arbitrary_tags' ) );
-		if ( is_array( $arbitrary_tags ) ) {
-			foreach ( $arbitrary_tags as $tag ) {
-				$this->meta_field( $tag['name'], $this->format( $tag['content'] ) );
-			}
-		}
+	/**
+	 * @deprecated
+	 */
+	public function get_term_option_name( $term ) {
+		_deprecated_function( __FUNCTION__, '1.0', 'wp_seo_get_term_option_name()' );
+		return wp_seo_get_term_option_name( $term );
+	}
 
+	/**
+	 * @deprecated
+	 */
+	public function add_term_meta_fields( $taxonomy ) {
+		_deprecated_function( __FUNCTION__, '1.0', 'WP_SEO_Term_Meta_Boxes::taxonomy_add_form_fields()' );
+		WP_SEO_Term_Meta_Boxes::taxonomy_add_form_fields( $taxonomy );
+	}
+
+	/**
+	 * @deprecated
+	 */
+	public function edit_term_meta_fields( $tag, $taxonomy ) {
+		_deprecated_function( __FUNCTION__, '1.0', 'WP_SEO_Term_Meta_Boxes::taxonomy_edit_form()' );
+		WP_SEO_Term_Meta_Boxes::taxonomy_edit_form( $tag, $taxonomy );
+	}
+
+	/**
+	 * @deprecated
+	 */
+	public function save_term_fields( $term_id, $term_taxonomy_id, $taxonomy ) {
+		_deprecated_function( __FUNCTION__, '1.0', 'WP_SEO_Term_Meta_Boxes::created_term() or WP_SEO_Term_Meta_Boxes::edited_term()' );
+		WP_SEO_Term_Meta_Boxes::edited_term( $term_id, $term_taxonomy_id, $taxonomy );
 	}
 
 }
 
-function WP_SEO() {
-	return WP_SEO::instance();
+function wp_seo() {
+	return wp_seo::instance();
 }
-add_action( 'after_setup_theme', 'WP_SEO' );
-
-endif;
+add_action( 'get_header', 'wp_seo' );

--- a/php/class-wp-seo.php
+++ b/php/class-wp-seo.php
@@ -380,6 +380,6 @@ class WP_SEO {
 }
 
 function wp_seo() {
-	return wp_seo::instance();
+	return WP_SEO::instance();
 }
 add_action( 'get_header', 'wp_seo' );

--- a/php/functions.php
+++ b/php/functions.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Helper and miscellaneous functions.
+ *
+ * @package WP_SEO
+ */
+
+/**
+ * Get the WP SEO meta box heading.
+ *
+ * @return string
+ */
+function wp_seo_meta_box_heading() {
+	/**
+	 * Filter the heading above SEO fields on edit-post screens.
+	 *
+	 * @param string The text. Default is "Search Engine Optimization."
+	 */
+	return apply_filters( 'wp_seo_box_heading', __( 'Search Engine Optimization', 'wp-seo' ) );
+}
+
+/**
+ * Get the translated <noscript> text for the character count.
+ *
+ * @param string $text The text to count.
+ * @return string The text to go between the <noscript> tags.
+ */
+function wp_seo_noscript_character_count( $text ) {
+	return sprintf( __( '%d (save changes to update)', 'wp-seo' ), strlen( $text ) );
+}
+
+/**
+ * Construct an option name for per-term SEO fields.
+ *
+ * @param object $term The term object.
+ * @return string The option name.
+ */
+function wp_seo_get_term_option_name( $term ) {
+	return "wp-seo-term-{$term->term_taxonomy_id}";
+}
+
+/**
+ * Enqueue scripts for admin pages.
+ */
+function wp_seo_admin_scripts() {
+	wp_enqueue_script( 'wp-seo-admin', WP_SEO_URL . 'js/wp-seo.js', array( 'jquery', 'underscore' ), '0.9.0', true );
+	wp_localize_script( 'wp-seo-admin', 'wp_seo_admin', array(
+		'repeatable_add_more_label' => __( 'Add another', 'wp-seo' ),
+		'repeatable_remove_label' => __( 'Remove group', 'wp-seo' ),
+	) );
+
+	wp_enqueue_style( 'wp-seo-admin', WP_SEO_URL . 'css/wp-seo.css', array(), '0.9.0' );
+}
+add_action( 'admin_enqueue_scripts', 'wp_seo_admin_scripts' );

--- a/wp-seo.php
+++ b/wp-seo.php
@@ -22,28 +22,33 @@
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-define( 'WP_SEO_PATH', dirname( __FILE__ ) );
-define( 'WP_SEO_URL', trailingslashit( plugins_url( '', __FILE__ ) ) );
+if ( ! class_exists( 'WP_SEO' ) ) {
 
-// Core filters for the page title and meta tags, and post and term metaboxes.
-require_once WP_SEO_PATH . '/php/class-wp-seo.php';
+	define( 'WP_SEO_PATH', dirname( __FILE__ ) );
+	define( 'WP_SEO_URL', trailingslashit( plugins_url( '', __FILE__ ) ) );
 
-// Settings page and option management.
-require_once WP_SEO_PATH . '/php/class-wp-seo-settings.php';
+	// Extendable formatting-tag class.
+	require_once ( WP_SEO_PATH . '/php/class-wp-seo-formatting-tag.php' );
 
-// Extendable formatting-tag class.
-require_once WP_SEO_PATH . '/php/class-wp-seo-formatting-tag.php';
+	// Bundled formatting tags.
+	require_once ( WP_SEO_PATH . '/php/default-formatting-tags.php' );
 
-// Included formatting tags.
-require_once WP_SEO_PATH . '/php/default-formatting-tags.php';
+	// Settings page and option management.
+	require_once ( WP_SEO_PATH . '/php/class-wp-seo-settings.php' );
 
-function wp_seo_admin_scripts() {
-	wp_enqueue_script( 'wp-seo-admin', WP_SEO_URL . 'js/wp-seo.js', array( 'jquery', 'underscore' ), '0.9.0', true );
-	wp_localize_script( 'wp-seo-admin', 'wp_seo_admin', array(
-		'repeatable_add_more_label' => __( 'Add another', 'wp-seo' ),
-		'repeatable_remove_label' => __( 'Remove group', 'wp-seo' ),
-	) );
+	// Post meta boxes.
+	require_once ( WP_SEO_PATH . '/php/class-wp-seo-post-meta-boxes.php' );
 
-	wp_enqueue_style( 'wp-seo-admin', WP_SEO_URL . 'css/wp-seo.css', array(), '0.9.0' );
+	// Term meta boxes.
+	require_once ( WP_SEO_PATH . '/php/class-wp-seo-term-meta-boxes.php' );
+
+	// Get WP SEO values for a query.
+	require_once ( WP_SEO_PATH . '/php/class-wp-seo-query.php' );
+
+	// Filter the page title and render meta tags.
+	require_once ( WP_SEO_PATH . '/php/class-wp-seo.php' );
+
+	// Common helpers and miscellaneous functions.
+	require_once( WP_SEO_PATH . '/php/functions.php' );
+
 }
-add_action( 'admin_enqueue_scripts', 'wp_seo_admin_scripts' );


### PR DESCRIPTION
This is (hopefully) the first in a set of PRs to refactor the plugin into a 1.0 release.

These changes are mostly described in 2640deba7d6508beb4fb19c8d7257de34ede5c67, but there are still more `@todo`s than mentioned there. I'm using the `refactor` branch to work on these changes before submitting them to `master`. 