### PR TITLE
Add base singleton class and formatting-tag classes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,3 +28,6 @@ before_script:
     - sed -i "s/yourpasswordhere//" /tmp/wordpress/wp-tests-config.php
 
 script: phpunit
+
+notifications:
+    email: false

--- a/php/class-wp-seo-formatter.php
+++ b/php/class-wp-seo-formatter.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Class file for WP_SEO_Formatter.
+ *
+ * @package WP_SEO
+ */
+
+/**
+ * Formats the formatting tags.
+ */
+class WP_SEO_Formatter extends WP_SEO_Singleton {
+
+	/**
+	 * Replace formatting tags in a string with their value for the current page.
+	 *
+	 * @param string $string The string with formatting tags.
+	 * @return string|WP_Error The formatted string, or WP_Error on error.
+	 */
+	public function format( $string ) {
+		if ( ! is_string( $string ) ) {
+			return new WP_Error( 'format_error', __( "Please don't try to format() a non-string.", 'wp-seo' ) );
+		}
+
+		$raw_string = $string;
+
+		preg_match_all( $this->get_formatting_tag_pattern(), $string, $matches );
+		if ( empty( $matches[0] ) ) {
+			return $string;
+		}
+
+		$replacements = array();
+		$unique_matches = array_unique( $matches[0] );
+
+		foreach ( WP_SEO_Formatting_Tag_Collection::instance()->get_all() as $id => $tag ) {
+			if ( ! empty( $tag->tag ) && in_array( $tag->tag, $unique_matches ) ) {
+				/**
+				 * Filter the value of a formatting tag for the current page.
+				 *
+				 * The dynamic portion of the hook name, `$id`, refers to the
+				 * key used to register the formatting tag. For example, the
+				 * hook for the default "#site_name#" formatting tag is
+				 * 'wp_seo_format_site_name'.
+				 *
+				 * @see wp_seo_default_formatting_tags() for the defaults' keys.
+				 *
+				 * @param string The value returned by the formatting tag.
+				 */
+				$replacements[ $tag->tag ] = apply_filters( "wp_seo_format_{$id}", $tag->get_value() );
+			}
+		}
+
+		if ( ! empty( $replacements ) ) {
+			$string = str_replace( array_keys( $replacements ), array_values( $replacements ), $string );
+		}
+
+		/**
+		 * Filter the formatted string.
+		 *
+		 * @param string $string The formatted string.
+		 * @param string $raw_string The string as submitted.
+		 */
+		return apply_filters( 'wp_seo_after_format_string', $string, $raw_string );
+	}
+
+	/**
+	 * Get the regular expression used to find formatting tags in a string.
+	 *
+	 * @return string The regex.
+	 */
+	public function get_formatting_tag_pattern() {
+		/**
+		 * Filter the regular expression used to find formatting tags in a string.
+		 *
+		 * You might filter this if you want to add unusual custom tags.
+		 *
+		 * @param string $formatting_tag_pattern The regex.
+		 */
+		return apply_filters( 'wp_seo_formatting_tag_pattern', '/#[a-zA-Z\_]+#/' );
+	}
+
+}

--- a/php/class-wp-seo-formatting-tag-collection.php
+++ b/php/class-wp-seo-formatting-tag-collection.php
@@ -13,7 +13,7 @@ class WP_SEO_Formatting_Tag_Collection extends WP_SEO_Singleton {
 	/**
 	 * Associative array of WP_SEO_Formatting_Tag IDs and instances.
 	 *
-	 * @var array.
+	 * @var array
 	 */
 	private $items = array();
 

--- a/php/class-wp-seo-formatting-tag-collection.php
+++ b/php/class-wp-seo-formatting-tag-collection.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Class file for WP_SEO_Formatting_Tag_Collection.
+ *
+ * @package WP_SEO
+ */
+
+/**
+ * Stores available instances of {@see WP_SEO_Formatting_Tag}.
+ */
+class WP_SEO_Formatting_Tag_Collection extends WP_SEO_Singleton {
+
+	/**
+	 * Associative array of WP_SEO_Formatting_Tag IDs and instances.
+	 *
+	 * @var array.
+	 */
+	private $items = array();
+
+	/**
+	 * @codeCoverageIgnore
+	 */
+	protected function setup() {
+		/**
+		 * Filter the available formatting tags when instantiating the collection.
+		 *
+		 * @see wp_seo_default_formatting_tags() for an example implementation.
+		 *
+		 * @param array $tags Associative array of WP_SEO_Formatting_Tag instances.
+		 */
+		$tags = apply_filters( 'wp_seo_formatting_tags', array() );
+		array_walk( $tags, array( $this, 'add' ) );
+	}
+
+	/**
+	 * Add a formatting tag to the collection.
+	 *
+	 * @param WP_SEO_Formatting_Tag $tag Formatting tag instance.
+	 * @param string $id Unique reference ID to register the tag under.
+	 */
+	public function add( $tag, $id ) {
+		if ( $tag instanceof WP_SEO_Formatting_Tag ) {
+			$this->items[ $id ] = $tag;
+		}
+	}
+
+	/**
+	 * Get all formatting tag instances in the collection.
+	 *
+	 * @return array Associative array of WP_SEO_Formatting_Tag IDs and instances.
+	 */
+	public function get_all() {
+		return $this->items;
+	}
+
+}

--- a/php/class-wp-seo-singleton.php
+++ b/php/class-wp-seo-singleton.php
@@ -25,6 +25,20 @@ abstract class WP_SEO_Singleton {
 	}
 
 	/**
+	 * @codeCoverageIgnore
+	 */
+	public function __clone() {
+		wp_die( sprintf( __( "Please don't __clone %s", "wp-seo" ), get_called_class() ) );
+	}
+
+	/**
+	 * @codeCoverageIgnore
+	 */
+	public function __wakeup() {
+		wp_die( sprintf( __( "Please don't __wakeup %s", "wp-seo" ), get_called_class() ) );
+	}
+
+	/**
 	 * Return an instance of a child class.
 	 *
 	 * @return WP_SEO_Singleton

--- a/php/class-wp-seo-singleton.php
+++ b/php/class-wp-seo-singleton.php
@@ -28,14 +28,14 @@ abstract class WP_SEO_Singleton {
 	 * @codeCoverageIgnore
 	 */
 	public function __clone() {
-		wp_die( sprintf( __( "Please don't __clone %s", "wp-seo" ), get_called_class() ) );
+		wp_die( sprintf( __( "Please don't __clone %s", 'wp-seo' ), get_called_class() ) );
 	}
 
 	/**
 	 * @codeCoverageIgnore
 	 */
 	public function __wakeup() {
-		wp_die( sprintf( __( "Please don't __wakeup %s", "wp-seo" ), get_called_class() ) );
+		wp_die( sprintf( __( "Please don't __wakeup %s", 'wp-seo' ), get_called_class() ) );
 	}
 
 	/**

--- a/php/class-wp-seo-singleton.php
+++ b/php/class-wp-seo-singleton.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Class file for WP_SEO_Singleton.
+ *
+ * @package WP_SEO
+ */
+
+/**
+ * Base singleton class.
+ */
+abstract class WP_SEO_Singleton {
+
+	/**
+	 * Instances of child classes.
+	 *
+	 * @var array
+	 */
+	private static $instances = array();
+
+	/**
+	 * @codeCoverageIgnore
+	 */
+	protected function __construct() {
+		/* Initialization typically happens via instance() method. */
+	}
+
+	/**
+	 * Return an instance of a child class.
+	 *
+	 * @return WP_SEO_Singleton
+	 */
+	public static function instance() {
+		$class = get_called_class();
+
+		if ( ! isset( self::$instances[ $class ] ) ) {
+			self::$instances[ $class ] = new static;
+			self::$instances[ $class ]->setup();
+		}
+
+		return self::$instances[ $class ];
+	}
+
+	/**
+	 * Initialize properties, add actions and filters.
+	 *
+	 * @codeCoverageIgnore
+	 */
+	protected function setup() {}
+
+}

--- a/php/class-wp-seo.php
+++ b/php/class-wp-seo.php
@@ -358,7 +358,7 @@ class WP_SEO {
 	 */
 	public function add_term_meta_fields( $taxonomy ) {
 		_deprecated_function( __FUNCTION__, '1.0', 'WP_SEO_Term_Meta_Boxes::taxonomy_add_form_fields()' );
-		WP_SEO_Term_Meta_Boxes::taxonomy_add_form_fields( $taxonomy );
+		WP_SEO_Term_Meta_Boxes::instance()->taxonomy_add_form_fields( $taxonomy );
 	}
 
 	/**
@@ -366,7 +366,7 @@ class WP_SEO {
 	 */
 	public function edit_term_meta_fields( $tag, $taxonomy ) {
 		_deprecated_function( __FUNCTION__, '1.0', 'WP_SEO_Term_Meta_Boxes::taxonomy_edit_form()' );
-		WP_SEO_Term_Meta_Boxes::taxonomy_edit_form( $tag, $taxonomy );
+		WP_SEO_Term_Meta_Boxes::instance()->taxonomy_edit_form( $tag, $taxonomy );
 	}
 
 	/**
@@ -374,7 +374,7 @@ class WP_SEO {
 	 */
 	public function save_term_fields( $term_id, $term_taxonomy_id, $taxonomy ) {
 		_deprecated_function( __FUNCTION__, '1.0', 'WP_SEO_Term_Meta_Boxes::created_term() or WP_SEO_Term_Meta_Boxes::edited_term()' );
-		WP_SEO_Term_Meta_Boxes::edited_term( $term_id, $term_taxonomy_id, $taxonomy );
+		WP_SEO_Term_Meta_Boxes::instance()->edited_term( $term_id, $term_taxonomy_id, $taxonomy );
 	}
 
 }

--- a/wp-seo.php
+++ b/wp-seo.php
@@ -28,7 +28,7 @@ if ( ! class_exists( 'WP_SEO' ) ) {
 	define( 'WP_SEO_URL', trailingslashit( plugins_url( '', __FILE__ ) ) );
 
 	// Base singleton class.
-	require_once( WP_SEO_PATH . '/php/class-wp-seo-singleton.php' );
+	require_once ( WP_SEO_PATH . '/php/class-wp-seo-singleton.php' );
 
 	// Extendable formatting-tag class.
 	require_once ( WP_SEO_PATH . '/php/class-wp-seo-formatting-tag.php' );

--- a/wp-seo.php
+++ b/wp-seo.php
@@ -27,6 +27,9 @@ if ( ! class_exists( 'WP_SEO' ) ) {
 	define( 'WP_SEO_PATH', dirname( __FILE__ ) );
 	define( 'WP_SEO_URL', trailingslashit( plugins_url( '', __FILE__ ) ) );
 
+	// Base singleton class.
+	require_once( WP_SEO_PATH . '/php/class-wp-seo-singleton.php' );
+
 	// Extendable formatting-tag class.
 	require_once ( WP_SEO_PATH . '/php/class-wp-seo-formatting-tag.php' );
 

--- a/wp-seo.php
+++ b/wp-seo.php
@@ -34,13 +34,13 @@ if ( ! class_exists( 'WP_SEO' ) ) {
 	require_once ( WP_SEO_PATH . '/php/class-wp-seo-formatting-tag.php' );
 
 	// Stores available formatting tag instances.
-	require_once( WP_SEO_PATH . '/php/class-wp-seo-formatting-tag-collection.php' );
+	require_once ( WP_SEO_PATH . '/php/class-wp-seo-formatting-tag-collection.php' );
 
 	// Bundled formatting tags.
 	require_once ( WP_SEO_PATH . '/php/default-formatting-tags.php' );
 
 	// Formatting tag formatter.
-	require_once( WP_SEO_PATH . '/php/class-wp-seo-formatter.php' );
+	require_once ( WP_SEO_PATH . '/php/class-wp-seo-formatter.php' );
 
 	// Settings page and option management.
 	require_once ( WP_SEO_PATH . '/php/class-wp-seo-settings.php' );

--- a/wp-seo.php
+++ b/wp-seo.php
@@ -33,8 +33,14 @@ if ( ! class_exists( 'WP_SEO' ) ) {
 	// Extendable formatting-tag class.
 	require_once ( WP_SEO_PATH . '/php/class-wp-seo-formatting-tag.php' );
 
+	// Stores available formatting tag instances.
+	require_once( WP_SEO_PATH . '/php/class-wp-seo-formatting-tag-collection.php' );
+
 	// Bundled formatting tags.
 	require_once ( WP_SEO_PATH . '/php/default-formatting-tags.php' );
+
+	// Formatting tag formatter.
+	require_once( WP_SEO_PATH . '/php/class-wp-seo-formatter.php' );
 
 	// Settings page and option management.
 	require_once ( WP_SEO_PATH . '/php/class-wp-seo-settings.php' );

--- a/wp-seo.php
+++ b/wp-seo.php
@@ -28,36 +28,36 @@ if ( ! class_exists( 'WP_SEO' ) ) {
 	define( 'WP_SEO_URL', trailingslashit( plugins_url( '', __FILE__ ) ) );
 
 	// Base singleton class.
-	require_once ( WP_SEO_PATH . '/php/class-wp-seo-singleton.php' );
+	require_once( WP_SEO_PATH . '/php/class-wp-seo-singleton.php' );
 
 	// Extendable formatting-tag class.
-	require_once ( WP_SEO_PATH . '/php/class-wp-seo-formatting-tag.php' );
+	require_once( WP_SEO_PATH . '/php/class-wp-seo-formatting-tag.php' );
 
 	// Stores available formatting tag instances.
-	require_once ( WP_SEO_PATH . '/php/class-wp-seo-formatting-tag-collection.php' );
+	require_once( WP_SEO_PATH . '/php/class-wp-seo-formatting-tag-collection.php' );
 
 	// Bundled formatting tags.
-	require_once ( WP_SEO_PATH . '/php/default-formatting-tags.php' );
+	require_once( WP_SEO_PATH . '/php/default-formatting-tags.php' );
 
 	// Formatting tag formatter.
-	require_once ( WP_SEO_PATH . '/php/class-wp-seo-formatter.php' );
+	require_once( WP_SEO_PATH . '/php/class-wp-seo-formatter.php' );
 
 	// Settings page and option management.
-	require_once ( WP_SEO_PATH . '/php/class-wp-seo-settings.php' );
+	require_once( WP_SEO_PATH . '/php/class-wp-seo-settings.php' );
 
 	// Post meta boxes.
-	require_once ( WP_SEO_PATH . '/php/class-wp-seo-post-meta-boxes.php' );
+	require_once( WP_SEO_PATH . '/php/class-wp-seo-post-meta-boxes.php' );
 
 	// Term meta boxes.
-	require_once ( WP_SEO_PATH . '/php/class-wp-seo-term-meta-boxes.php' );
+	require_once( WP_SEO_PATH . '/php/class-wp-seo-term-meta-boxes.php' );
 
 	// Get WP SEO values for a query.
-	require_once ( WP_SEO_PATH . '/php/class-wp-seo-query.php' );
+	require_once( WP_SEO_PATH . '/php/class-wp-seo-query.php' );
 
 	// Filter the page title and render meta tags.
-	require_once ( WP_SEO_PATH . '/php/class-wp-seo.php' );
+	require_once( WP_SEO_PATH . '/php/class-wp-seo.php' );
 
 	// Common helpers and miscellaneous functions.
-	require_once ( WP_SEO_PATH . '/php/functions.php' );
+	require_once( WP_SEO_PATH . '/php/functions.php' );
 
 }

--- a/wp-seo.php
+++ b/wp-seo.php
@@ -52,6 +52,6 @@ if ( ! class_exists( 'WP_SEO' ) ) {
 	require_once ( WP_SEO_PATH . '/php/class-wp-seo.php' );
 
 	// Common helpers and miscellaneous functions.
-	require_once( WP_SEO_PATH . '/php/functions.php' );
+	require_once ( WP_SEO_PATH . '/php/functions.php' );
 
 }


### PR DESCRIPTION
Along with some other fixes, the main additions here are:

- A base singleton class (79d6c76)
- `WP_SEO_Formatter`, for replacing formatting tags in a string (f7112c6)
- `WP_SEO_Formatting_Tag_Collection`, for storing formatting tag instances (f7112c6)

Most of the code in the last two were formerly in `WP_SEO` (see also #28). `WP_SEO` itself is now mostly down to the `wp_title` and `wp_head` hooks.

The unit tests won't pass yet.