### PR TITLE
Use hooks to build post- and term-field markup

### DIFF
--- a/php/admin-functions.php
+++ b/php/admin-functions.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Administration functions.
+ *
+ * @package WP_SEO
+ */
+
+/**
+ * Get the default title above SEO fields on post- and term-edit screens.
+ *
+ * @return string The title.
+ */
+function wp_seo_get_box_title() {
+	/**
+	 * Filters the default title above SEO fields on post- and term-edit screens.
+	 *
+	 * @param string $title The title.
+	 */
+	return apply_filters( 'wp_seo_box_heading', __( 'Search Engine Optimization', 'wp-seo' ) );
+}
+
+/**
+ * Call printing function for the meta title input for a given post.
+ *
+ * @param int $post_id Post ID.
+ */
+function wp_seo_post_id_to_the_meta_title_input( $post_id ) {
+	wp_seo_the_meta_title_input( get_post_meta( $post_id, '_meta_title', true ) );
+}
+
+/**
+ * Call printing function for the title character count for a given post.
+ *
+ * @param int $post_id Post ID.
+ */
+function wp_seo_post_id_to_the_title_character_count( $post_id ) {
+	wp_seo_the_title_character_count( strlen( get_post_meta( $post_id, '_meta_title', true ) ) );
+}
+
+/**
+ * Call printing function for the meta description input for a given post.
+ *
+ * @param int $post_id Post ID.
+ */
+function wp_seo_post_id_to_the_meta_description_input( $post_id ) {
+	wp_seo_the_meta_description_input( get_post_meta( $post_id, '_meta_description', true ) );
+}
+
+/**
+ * Call printing function for the description character count for a given post.
+ *
+ * @param int $post_id Post ID.
+ */
+function wp_seo_post_id_to_the_description_character_count( $post_id ) {
+	wp_seo_the_description_character_count( strlen( get_post_meta( $post_id, '_meta_description', true ) ) );
+}
+
+/**
+ * Call printing function for the meta keywords input for a given post.
+ *
+ * @param int $post_id Post ID.
+ */
+function wp_seo_post_id_to_the_meta_keywords_input( $post_id ) {
+	wp_seo_the_meta_keywords_input( get_post_meta( $post_id, '_meta_keywords', true ) );
+}
+
+/**
+ * Call printing function for the meta title input for a given term.
+ *
+ * @param int $term_id Term ID.
+ * @param string $taxonomy The taxonomy slug.
+ */
+function wp_seo_term_data_to_the_meta_title_input( $term_id, $taxonomy ) {
+	$term_option = WP_SEO()->intersect_term_option( (array) WP_SEO()->get_term_option( $term_id, $taxonomy ) );
+	wp_seo_the_meta_title_input( $term_option['title'] );
+}
+
+/**
+ * Call printing function for the title character count for a given term.
+ *
+ * @param int $term_id Term ID.
+ * @param string $taxonomy The taxonomy slug.
+ */
+function wp_seo_term_data_to_the_title_character_count( $term_id, $taxonomy ) {
+	$term_option = WP_SEO()->intersect_term_option( (array) WP_SEO()->get_term_option( $term_id, $taxonomy ) );
+	wp_seo_the_title_character_count( strlen( $term_option['title'] ) );
+}
+
+/**
+ * Call printing function for the meta description input for a given term.
+ *
+ * @param int $term_id Term ID.
+ * @param string $taxonomy The taxonomy slug.
+ */
+function wp_seo_term_data_to_the_meta_description_input( $term_id, $taxonomy ) {
+	$term_option = WP_SEO()->intersect_term_option( (array) WP_SEO()->get_term_option( $term_id, $taxonomy ) );
+	wp_seo_the_meta_description_input( $term_option['description'] );
+}
+
+/**
+ * Call printing function for the description character count for a given term.
+ *
+ * @param int $term_id Term ID.
+ * @param string $taxonomy The taxonomy slug.
+ */
+function wp_seo_term_data_to_the_description_character_count( $term_id, $taxonomy ) {
+	$term_option = WP_SEO()->intersect_term_option( (array) WP_SEO()->get_term_option( $term_id, $taxonomy ) );
+	wp_seo_the_description_character_count( strlen( $term_option['description'] ) );
+}
+
+/**
+ * Call printing function for the meta keywords input for a given term.
+ *
+ * @param int $term_id Term ID.
+ * @param string $taxonomy The taxonomy slug.
+ */
+function wp_seo_term_data_to_the_meta_keywords_input( $term_id, $taxonomy ) {
+	$term_option = WP_SEO()->intersect_term_option( (array) WP_SEO()->get_term_option( $term_id, $taxonomy ) );
+	wp_seo_the_meta_keywords_input( $term_option['keywords'] );
+}

--- a/php/admin-template.php
+++ b/php/admin-template.php
@@ -1,0 +1,343 @@
+<?php
+/**
+ * Administration template tags.
+ *
+ * @package WP_SEO
+ */
+
+/**
+ * Prints markup and fires actions to construct the default WP SEO post metabox.
+ *
+ * @param WP_Post $post Post object of the post being edited.
+ */
+function wp_seo_the_post_meta_fields( $post ) {
+	?>
+	<table class="wp-seo-post-meta-fields">
+		<tbody>
+			<tr>
+				<th scope="row">
+					<?php
+					/**
+					 * Fires to print the meta title input label in the post metabox.
+					 */
+					do_action( 'wp_seo_post_meta_fields_title_label' );
+					?>
+				</th>
+				<td>
+					<?php
+					/**
+					 * Fires to print the meta title input in the post metabox.
+					 *
+					 * @param int $post_id The ID of the post being edited.
+					 */
+					do_action( 'wp_seo_post_meta_fields_title_input', $post->ID );
+
+					/**
+					 * Fires after the meta title input in the post metabox.
+					 *
+					 * @param int $post_id The ID of the post being edited.
+					 */
+					do_action( 'wp_seo_post_meta_fields_after_title_input', $post->ID );
+					?>
+				</td>
+			</tr>
+			<tr>
+				<th scope="row">
+					<?php
+					/**
+					 * Fires to print the meta description label in the post metabox.
+					 */
+					do_action( 'wp_seo_post_meta_fields_description_label' );
+					?>
+				</th>
+				<td>
+					<?php
+					/**
+					 * Fires to print the meta description input in the post metabox.
+					 *
+					 * @param int $post_id The ID of the post being edited.
+					 */
+					do_action( 'wp_seo_post_meta_fields_description_input', $post->ID );
+
+					/**
+					 * Fires after the meta description input in the post metabox.
+					 *
+					 * @param int $post_id The ID of the post being edited.
+					 */
+					do_action( 'wp_seo_post_meta_fields_after_description_input', $post->ID );
+					?>
+				<td>
+			</tr>
+			<tr>
+				<th scope="row">
+					<?php
+					/**
+					 * Fires to print the meta keywords label in the post metabox.
+					 */
+					do_action( 'wp_seo_post_meta_fields_keywords_label' );
+					?>
+				</th>
+				<td>
+					<?php
+					/**
+					 * Fires to print the meta keywords input in the post metabox.
+					 *
+					 * @param int $post_id The ID of the post being edited.
+					 */
+					do_action( 'wp_seo_post_meta_fields_keywords_input', $post->ID );
+					?>
+				</td>
+			</tr>
+		</tbody>
+	</table>
+	<?php
+}
+
+/**
+ * Prints markup and fires actions to place the default WP SEO fields on the add-term screen.
+ *
+ * @param string $taxonomy The taxonomy to which a term is being added.
+ */
+function wp_seo_the_add_term_meta_fields( $taxonomy ) {
+	?>
+	<h3><?php echo esc_html( wp_seo_get_box_title() ); ?></h3>
+
+	<div class="wp-seo-term-meta-fields">
+		<div class="form-field">
+			<?php
+			/**
+			 * Fires to print the meta title input label with the add-term meta fields.
+			 */
+			do_action( 'wp_seo_add_term_meta_fields_title_label' );
+
+			/**
+			 * Fires to print the meta title input label with the add-term meta fields.
+			 */
+			do_action( 'wp_seo_add_term_meta_fields_title_input' );
+
+			/**
+			 * Fires after the meta title input with the add-term meta fields.
+			 */
+			do_action( 'wp_seo_add_term_meta_fields_after_title_input' );
+			?>
+		</div>
+		<div class="form-field">
+			<?php
+			/**
+			 * Fires to print the meta description label with the add-term meta fields.
+			 */
+			do_action( 'wp_seo_add_term_meta_fields_description_label' );
+
+			/**
+			 * Fires to print the meta description input with the add-term meta fields.
+			 */
+			do_action( 'wp_seo_add_term_meta_fields_description_input' );
+
+			/**
+			 * Fires after the meta description input with the add-term meta fields.
+			 */
+			do_action( 'wp_seo_add_term_meta_fields_after_description_input' );
+			?>
+		</div>
+		<div class="form-field">
+			<?php
+			/**
+			 * Fires to print the meta keywords label with the add-term meta fields.
+			 */
+			do_action( 'wp_seo_add_term_meta_fields_keywords_label' );
+
+			/**
+			 * Fires to print the meta keywords input with the add-term meta fields.
+			 */
+			do_action( 'wp_seo_add_term_meta_fields_keywords_input' );
+			?>
+		</div>
+	</div>
+	<?php
+}
+
+/**
+ * Prints markup and fires actions to place the default WP SEO fields on the edit-term screen.
+ *
+ * @param WP_Term $tag The term object.
+ * @param string $taxonomy The taxonomy slug.
+ */
+function wp_seo_the_edit_term_meta_fields( $tag, $taxonomy ) {
+	?>
+	<h2><?php echo esc_html( wp_seo_get_box_title() ); ?></h2>
+
+	<table class="form-table wp-seo-term-meta-fields">
+		<tbody>
+			<tr class="form-field">
+				<th scope="row">
+					<?php
+					/**
+					 * Fires to print the meta title input label with the edit-term meta fields.
+					 */
+					do_action( 'wp_seo_edit_term_meta_fields_title_label' );
+					?>
+				</th>
+				<td>
+					<?php
+					/**
+					 * Fires to print the meta title input with the edit-term meta fields.
+					 *
+					 * @param int $term_id The term ID of the term being edited.
+					 * @param string $taxonomy The taxonomy slug.
+					 */
+					do_action( 'wp_seo_edit_term_meta_fields_title_input', $tag->term_id, $taxonomy );
+
+					/**
+					 * Fires after the meta title input with the edit-term meta fields.
+					 *
+					 * @param int $term_id The term ID of the term being edited.
+					 * @param string $taxonomy The taxonomy slug.
+					 */
+					do_action( 'wp_seo_edit_term_meta_fields_after_title_input', $tag->term_id, $taxonomy );
+					?>
+				</td>
+			</tr>
+			<tr class="form-field">
+				<th scope="row">
+					<?php
+					/**
+					 * Fires to print the meta description label with the edit-term meta fields.
+					 */
+					do_action( 'wp_seo_edit_term_meta_fields_description_label' );
+					?>
+				</th>
+				<td>
+					<?php
+					/**
+					 * Fires to print the meta description input with the edit-term meta fields.
+					 *
+					 * @param int $term_id The term ID of the term being edited.
+					 * @param string $taxonomy The taxonomy slug.
+					 */
+					do_action( 'wp_seo_edit_term_meta_fields_description_input', $tag->term_id, $taxonomy );
+
+					/**
+					 * Fires after the meta description input with the edit-term meta fields.
+					 *
+					 * @param int $term_id The term ID of the term being edited.
+					 * @param string $taxonomy The taxonomy slug.
+					 */
+					do_action( 'wp_seo_edit_term_meta_fields_after_description_input', $tag->term_id, $taxonomy );
+					?>
+				<td>
+			</tr>
+			<tr class="form-field">
+				<th scope="row">
+					<?php
+					/**
+					 * Fires to print the meta keywords label with the edit-term meta fields.
+					 */
+					do_action( 'wp_seo_edit_term_meta_fields_keywords_label' );
+					?>
+				</th>
+				<td>
+					<?php
+					/**
+					 * Fires to print the meta keywords input with the edit-term meta fields.
+					 *
+					 * @param int $term_id The term ID of the term being edited.
+					 * @param string $taxonomy The taxonomy slug.
+					 */
+					do_action( 'wp_seo_edit_term_meta_fields_keywords_input', $tag->term_id, $taxonomy );
+					?>
+				</td>
+			</tr>
+		</tbody>
+	</table>
+	<?php
+}
+
+/**
+ * Prints a form label for a meta title input.
+ */
+function wp_seo_the_meta_title_label() {
+	?>
+	<label for="wp_seo_meta_title"><?php esc_html_e( 'Title Tag', 'wp-seo' ); ?></label>
+	<?php
+}
+
+/**
+ * Prints a form input for a meta title.
+ *
+ * @param string $value The input's current value.
+ */
+function wp_seo_the_meta_title_input( $value ) {
+	?>
+	<input type="text" id="wp_seo_meta_title" name="seo_meta[title]" value="<?php echo esc_attr( $value ); ?>" size="96" />
+	<?php
+}
+
+/**
+ * Prints markup for displaying a meta title input's character count.
+ *
+ * @param string $count The starting character count.
+ */
+function wp_seo_the_title_character_count( $count ) {
+	?>
+	<p>
+		<?php esc_html_e( 'Title character count: ', 'wp-seo' ); ?>
+		<span class="title-character-count"></span>
+		<noscript><?php echo esc_html( sprintf( __( '%d (save changes to update)', 'wp-seo' ), $count ) ); ?></noscript>
+	</p>
+	<?php
+}
+
+/**
+ * Prints a form label for a meta description input.
+ */
+function wp_seo_the_meta_description_label() {
+	?>
+	<label for="wp_seo_meta_description"><?php esc_html_e( 'Meta Description', 'wp-seo' ); ?></label>
+	<?php
+}
+
+/**
+ * Prints a form input for a meta description.
+ *
+ * @param string $value The input's current value.
+ */
+function wp_seo_the_meta_description_input( $value ) {
+	?>
+	<textarea id="wp_seo_meta_description" name="seo_meta[description]" rows="2" cols="96"><?php echo esc_textarea( $value ); ?></textarea>
+	<?php
+}
+
+/**
+ * Prints markup for displaying a meta description input's character count.
+ *
+ * @param string $count The starting character count.
+ */
+function wp_seo_the_description_character_count( $count ) {
+	?>
+	<p>
+		<?php esc_html_e( 'Description character count: ', 'wp-seo' ); ?>
+		<span class="description-character-count"></span>
+		<noscript><?php echo esc_html( sprintf( __( '%d (save changes to update)', 'wp-seo' ), $count ) ); ?></noscript>
+	</p>
+	<?php
+}
+
+/**
+ * Prints a form label for a meta keywords input.
+ */
+function wp_seo_the_meta_keywords_label() {
+	?>
+	<label for="wp_seo_meta_keywords"><?php esc_html_e( 'Meta Keywords', 'wp-seo' ); ?></label>
+	<?php
+}
+
+/**
+ * Prints a form input for meta keywords.
+ *
+ * @param string $value The input's current value.
+ */
+function wp_seo_the_meta_keywords_input( $value ) {
+	?>
+	<textarea id="wp_seo_meta_keywords" name="seo_meta[keywords]" rows="2" cols="96"><?php echo esc_textarea( $value ); ?></textarea>
+	<?php
+}

--- a/php/default-filters.php
+++ b/php/default-filters.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Sets up the default filters and actions for most WP SEO hooks.
+ *
+ * If you need to remove a default hook, this file will give you the priority.
+ *
+ * Not all of the default hooks are here (yet).
+ *
+ * @package WP_SEO
+ */
+
+add_action( 'wp_seo_post_meta_fields',                                          'wp_seo_the_post_meta_fields' );
+add_action( 'wp_seo_post_meta_fields_title_label',                              'wp_seo_the_meta_title_label' );
+add_action( 'wp_seo_post_meta_fields_title_input',                              'wp_seo_post_id_to_the_meta_title_input' );
+add_action( 'wp_seo_post_meta_fields_after_title_input',                        'wp_seo_post_id_to_the_title_character_count' );
+add_action( 'wp_seo_post_meta_fields_description_label',                        'wp_seo_the_meta_description_label' );
+add_action( 'wp_seo_post_meta_fields_description_input',                        'wp_seo_post_id_to_the_meta_description_input' );
+add_action( 'wp_seo_post_meta_fields_after_description_input',                  'wp_seo_post_id_to_the_description_character_count' );
+add_action( 'wp_seo_post_meta_fields_keywords_label',                           'wp_seo_the_meta_keywords_label' );
+add_action( 'wp_seo_post_meta_fields_keywords_input',                           'wp_seo_post_id_to_the_meta_keywords_input' );
+
+add_action( 'wp_seo_add_term_meta_fields',                                      'wp_seo_the_add_term_meta_fields' );
+add_action( 'wp_seo_add_term_meta_fields_title_label',                          'wp_seo_the_meta_title_label' );
+add_action( 'wp_seo_add_term_meta_fields_title_input',                          'wp_seo_the_meta_title_input' );
+add_action( 'wp_seo_add_term_meta_fields_after_title_input',                    'wp_seo_the_title_character_count' );
+add_action( 'wp_seo_add_term_meta_fields_description_label',                    'wp_seo_the_meta_description_label' );
+add_action( 'wp_seo_add_term_meta_fields_description_input',                    'wp_seo_the_meta_description_input' );
+add_action( 'wp_seo_add_term_meta_fields_after_description_input',              'wp_seo_the_description_character_count' );
+add_action( 'wp_seo_add_term_meta_fields_keywords_label',                       'wp_seo_the_meta_keywords_label' );
+add_action( 'wp_seo_add_term_meta_fields_keywords_input',                       'wp_seo_the_meta_keywords_input' );
+
+add_action( 'wp_seo_edit_term_meta_fields',                                     'wp_seo_the_edit_term_meta_fields', 10, 2 );
+add_action( 'wp_seo_edit_term_meta_fields_title_label',                         'wp_seo_the_meta_title_label' );
+add_action( 'wp_seo_edit_term_meta_fields_title_input',                         'wp_seo_term_data_to_the_meta_title_input', 10, 2 );
+add_action( 'wp_seo_edit_term_meta_fields_after_title_input',                   'wp_seo_term_data_to_the_title_character_count', 10, 2 );
+add_action( 'wp_seo_edit_term_meta_fields_description_label',                   'wp_seo_the_meta_description_label' );
+add_action( 'wp_seo_edit_term_meta_fields_description_input',                   'wp_seo_term_data_to_the_meta_description_input', 10, 2 );
+add_action( 'wp_seo_edit_term_meta_fields_after_description_input',             'wp_seo_term_data_to_the_description_character_count', 10, 2 );
+add_action( 'wp_seo_edit_term_meta_fields_keywords_label',                      'wp_seo_the_meta_keywords_label' );
+add_action( 'wp_seo_edit_term_meta_fields_keywords_input',                      'wp_seo_term_data_to_the_meta_keywords_input', 10, 2 );

--- a/php/default-filters.php
+++ b/php/default-filters.php
@@ -9,6 +9,8 @@
  * @package WP_SEO
  */
 
+add_action( 'admin_init',                                                       'wp_seo_load_admin_files', 0 );
+
 add_action( 'wp_seo_post_meta_fields',                                          'wp_seo_the_post_meta_fields' );
 add_action( 'wp_seo_post_meta_fields_title_label',                              'wp_seo_the_meta_title_label' );
 add_action( 'wp_seo_post_meta_fields_title_input',                              'wp_seo_post_id_to_the_meta_title_input' );

--- a/php/general-functions.php
+++ b/php/general-functions.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * General functions.
+ *
+ * @package WP_SEO
+ */
+
+/**
+ * Merge user arguments into a defaults array without appending to the defaults.
+ *
+ * This can be useful when you want to make sure a new key can't be added to
+ * $args without also being added to $defaults, thus providing some security
+ * against undefined-index errors when the key is not included with $args in
+ * some future scenario.
+ *
+ * @param array $args Value to merge with defaults.
+ * @param array $defaults Defaults array.
+ * @return array The defaults after merging values for matching $args keys.
+ */
+function wp_seo_intersect_args( $args, $defaults ) {
+	return array_intersect_key( $args, $defaults ) + $defaults;
+}

--- a/php/internal-functions.php
+++ b/php/internal-functions.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Functions for WP SEO to use behind the scenes.
+ *
+ * @package WP_SEO
+ */
+
+/**
+ * Load plugin files used only in the admin.
+ */
+function wp_seo_load_admin_files() {
+	// Admin-only functions.
+	require_once WP_SEO_PATH . '/php/admin-functions.php';
+
+	// Admin-only template tags.
+	require_once WP_SEO_PATH . '/php/admin-template.php';
+}

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: alleyinteractive, mboynes, dlh
 Tags: seo
 Requires at least: 3.9.1
-Tested up to: 4.4.0
-Stable tag: 0.10.0
+Tested up to: 4.5.0
+Stable tag: 0.11.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -102,6 +102,9 @@ Use the "Remove group" button, or just remove the field content, to remove a cus
 3. Setting title and meta fields for a post
 
 == Changelog ==
+
+= 0.11.0 =
+* Add hooks for customizing post- and term-field markup.
 
 = 0.10.0 =
 * Add support for title tags generated with `wp_get_document_title()`, introduced in WordPress 4.4.

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -31,6 +31,7 @@ require_once $_tests_dir . '/includes/functions.php';
 
 function _manually_load_plugin() {
 	require dirname( __FILE__ ) . '/../wp-seo.php';
+	wp_seo_load_admin_files();
 }
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -34,4 +34,5 @@ function _manually_load_plugin() {
 }
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 
-require $_tests_dir . '/includes/bootstrap.php';
+require_once $_tests_dir . '/includes/bootstrap.php';
+require_once dirname( __FILE__ ) . '/includes/class-wp-seo-testcase.php';

--- a/tests/includes/class-wp-seo-testcase.php
+++ b/tests/includes/class-wp-seo-testcase.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * WP SEO test fixture.
+ *
+ * @package WP_SEO
+ */
+
+class WP_SEO_Testcase extends WP_UnitTestCase {
+	public function create_and_get_term_with_option( $option_value, $args = array() ) {
+		$term = $this->factory->term->create_and_get( $args );
+		update_option( WP_SEO::instance()->get_term_option_name( $term ), $option_value );
+		return get_term( $term->term_id, $term->taxonomy );
+	}
+}

--- a/tests/test-admin-functions.php
+++ b/tests/test-admin-functions.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Tests for admin-functions.php.
+ *
+ * @package WP_SEO
+ */
+
+class WP_SEO_Admin_Functions_Tests extends WP_SEO_Testcase {
+	/**
+	 * Sanity-check that the post_id_to_* and term_data_to_* functions use saved values.
+	 *
+	 * @dataProvider data_post_id_to_and_term_data_to
+	 */
+	function test_admin_functions_contain( $function, $should, $contain, $args ) {
+		$this->assertContains( $contain, get_echo( $function, $args ), $should );
+	}
+
+	/**
+	 * Combines the post_id_to_* and term_data_to_* data providers..
+	 */
+	function data_post_id_to_and_term_data_to() {
+		return array_merge( $this->data_post_id_to_functions(), $this->data_term_data_to_functions() );
+	}
+
+	/**
+	 * @return array {
+	 *     @type string $function Function name.
+	 *     @type string $should Message to describe the expected behavior on failure.
+	 *     @type string $contain Value the function output should contain, given $args.
+	 *     @type array $args Function arguments (for these functions, a post ID).
+	 * }
+	 */
+	function data_post_id_to_functions() {
+		$meta_title       = rand_str( rand( 32, 64 ) );
+		$meta_description = rand_str( rand( 32, 64 ) );
+		$meta_keywords    = rand_str( rand( 32, 64 ) );
+
+		$post_id = $this->factory->post->create( array(
+			'meta_input' => array(
+				'_meta_title'       => $meta_title,
+				'_meta_description' => $meta_description,
+				'_meta_keywords'    => $meta_keywords,
+			),
+		) );
+
+		return array(
+			array(
+				'wp_seo_post_id_to_the_meta_title_input',
+				'Should print the title value in post meta',
+				$meta_title,
+				array( $post_id ),
+			),
+			array(
+				'wp_seo_post_id_to_the_title_character_count',
+				'Should count the title value in post meta',
+				strlen( $meta_title ),
+				array( $post_id ),
+			),
+			array(
+				'wp_seo_post_id_to_the_meta_description_input',
+				'Should print the description value in post meta',
+				$meta_description,
+				array( $post_id ),
+			),
+			array(
+				'wp_seo_post_id_to_the_description_character_count',
+				'Should count the description value in post meta',
+				strlen( $meta_description ),
+				array( $post_id ),
+			),
+			array(
+				'wp_seo_post_id_to_the_meta_keywords_input',
+				'Should print the keyword value in post meta',
+				$meta_keywords,
+				array( $post_id ),
+			),
+		);
+	}
+
+	/**
+	 * @return array {
+	 *     @type string $function Function name.
+	 *     @type string $contain Value the function output should contain, given $args.
+	 *     @type array $args Function arguments (for these functions, a term's ID and taxonomy).
+	 * }
+	 */
+	function data_term_data_to_functions() {
+		$title       = rand_str( rand( 32, 64 ) );
+		$description = rand_str( rand( 32, 64 ) );
+		$keywords    = rand_str( rand( 32, 64 ) );
+
+		$term = $this->create_and_get_term_with_option( array(
+			'title' => $title,
+			'description' => $description,
+			'keywords' => $keywords,
+		) );
+
+		return array(
+			array(
+				'wp_seo_term_data_to_the_meta_title_input',
+				'Should print the title value in the term options',
+				$title,
+				array( $term->term_id, $term->taxonomy ),
+			),
+			array(
+				'wp_seo_term_data_to_the_title_character_count',
+				'Should count the title value in the term options',
+				strlen( $title ),
+				array( $term->term_id, $term->taxonomy ),
+			),
+			array(
+				'wp_seo_term_data_to_the_meta_description_input',
+				'Should print the description value in the term options',
+				$description,
+				array( $term->term_id, $term->taxonomy ),
+			),
+			array(
+				'wp_seo_term_data_to_the_description_character_count',
+				'Should count the description value in the term options',
+				strlen( $description ),
+				array( $term->term_id, $term->taxonomy ),
+			),
+			array(
+				'wp_seo_term_data_to_the_meta_keywords_input',
+				'Should print the keyword value in the term options',
+				$keywords,
+				array( $term->term_id, $term->taxonomy ),
+			),
+		);
+	}
+}

--- a/tests/test-admin-functions.php
+++ b/tests/test-admin-functions.php
@@ -16,7 +16,7 @@ class WP_SEO_Admin_Functions_Tests extends WP_SEO_Testcase {
 	}
 
 	/**
-	 * Combines the post_id_to_* and term_data_to_* data providers..
+	 * Combines the post_id_to_* and term_data_to_* data providers.
 	 */
 	function data_post_id_to_and_term_data_to() {
 		return array_merge( $this->data_post_id_to_functions(), $this->data_term_data_to_functions() );
@@ -53,7 +53,7 @@ class WP_SEO_Admin_Functions_Tests extends WP_SEO_Testcase {
 			array(
 				'wp_seo_post_id_to_the_title_character_count',
 				'Should count the title value in post meta',
-				strlen( $meta_title ),
+				(string) strlen( $meta_title ),
 				array( $post_id ),
 			),
 			array(
@@ -65,7 +65,7 @@ class WP_SEO_Admin_Functions_Tests extends WP_SEO_Testcase {
 			array(
 				'wp_seo_post_id_to_the_description_character_count',
 				'Should count the description value in post meta',
-				strlen( $meta_description ),
+				(string) strlen( $meta_description ),
 				array( $post_id ),
 			),
 			array(
@@ -105,7 +105,7 @@ class WP_SEO_Admin_Functions_Tests extends WP_SEO_Testcase {
 			array(
 				'wp_seo_term_data_to_the_title_character_count',
 				'Should count the title value in the term options',
-				strlen( $title ),
+				(string) strlen( $title ),
 				array( $term->term_id, $term->taxonomy ),
 			),
 			array(
@@ -117,7 +117,7 @@ class WP_SEO_Admin_Functions_Tests extends WP_SEO_Testcase {
 			array(
 				'wp_seo_term_data_to_the_description_character_count',
 				'Should count the description value in the term options',
-				strlen( $description ),
+				(string) strlen( $description ),
 				array( $term->term_id, $term->taxonomy ),
 			),
 			array(

--- a/tests/test-admin-template.php
+++ b/tests/test-admin-template.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * Tests for admin-template.php.
+ *
+ * @package WP_SEO
+ */
+
+class WP_SEO_Admin_Template_Tests extends WP_UnitTestCase {
+	/**
+	 * Sanity-check admin template tag output.
+	 *
+	 * @dataProvider data_template_tag_output
+	 */
+	function test_template_tag_output( $function, $should, $match, $args ) {
+		$this->assertRegExp( $match, get_echo( $function, $args ), $should );
+	}
+
+	/**
+	 * @return array {
+	 *    @type string $function Function name.
+	 *    @type string $should Message to describe the expected behavior on failure.
+	 *    @type string $match Regex to test against $function output.
+	 *    @type array $args Function arguments.
+	 * }
+	 */
+	function data_template_tag_output() {
+		$str = rand_str();
+		$num = rand( 1, 10 );
+
+		return array(
+			array(
+				'wp_seo_the_post_meta_fields',
+				'Should print a table',
+				'#<table[^>]*?>.+?</table>#s',
+				array( $this->factory->post->create_and_get() ),
+			),
+			array(
+				'wp_seo_the_add_term_meta_fields',
+				'Should print a heading',
+				'#<h(\d)[^>]*?>.+?</h\1>#',
+				array( $this->factory->term->create_and_get(), $str ),
+			),
+			array(
+				'wp_seo_the_edit_term_meta_fields',
+				'Should print a heading',
+				'#<h(\d)[^>]*?>.+?</h\1>#',
+				array( $this->factory->term->create_and_get(), $str ),
+			),
+			array(
+				'wp_seo_the_edit_term_meta_fields',
+				'Should print a table',
+				'#<table[^>]*?>.+?</table>#s',
+				array( $this->factory->term->create_and_get(), $str ),
+			),
+			array(
+				'wp_seo_the_meta_title_label',
+				'Should print a label',
+				'#<label[^>]*?>.+?</label>#',
+				array(),
+			),
+			array(
+				'wp_seo_the_meta_title_input',
+				'Should print an input',
+				'#<input[^>]+? />#',
+				array( '' ),
+			),
+			array(
+				'wp_seo_the_meta_title_input',
+				'Should print the passed value',
+				'#value=(.)\1#',
+				array( '' ),
+			),
+			array(
+				'wp_seo_the_meta_title_input',
+				'Should print the passed value',
+				'#value=(.)' . $str . '\1#',
+				array( $str ),
+			),
+			array(
+				'wp_seo_the_title_character_count',
+				'Should print the passed number',
+				"#{$num} \(save changes to update\)#s",
+				array( $num ),
+			),
+			array(
+				'wp_seo_the_meta_description_label',
+				'Should print a label',
+				'#<label[^>]*?>.+?</label>#',
+				array(),
+			),
+			array(
+				'wp_seo_the_meta_description_input',
+				'Should print an input',
+				'#<textarea[^>]*?></textarea>#',
+				array( '' ),
+			),
+			array(
+				'wp_seo_the_meta_description_input',
+				'Should print the passed value',
+				"#<textarea[^>]*?>{$str}</textarea>#",
+				array( $str ),
+			),
+			array(
+				'wp_seo_the_description_character_count',
+				'Should print the passed number',
+				"#{$num} \(save changes to update\)#s",
+				array( $num ),
+			),
+			array(
+				'wp_seo_the_meta_keywords_label',
+				'Should print a label',
+				'#<label[^>]*?>.+?</label>#',
+				array(),
+			),
+			array(
+				'wp_seo_the_meta_keywords_input',
+				'Should print an input',
+				'#<textarea[^>]*?></textarea>#',
+				array( '' ),
+			),
+			array(
+				'wp_seo_the_meta_keywords_input',
+				'Should print the passed value',
+				"#<textarea[^>]*?>{$str}</textarea>#",
+				array( $str ),
+			),
+		);
+	}
+
+	/**
+	 * Sanity-check the number of WP SEO hook calls in admin template tags.
+	 *
+	 * @dataProvider data_template_tag_hooks
+	 */
+	function test_template_tag_hooks( $function, $fires, $matching, $args ) {
+		$ma = new MockAction();
+		add_action( 'all', array( $ma, 'action' ) );
+		get_echo( $function, $args );
+		$this->assertSame( $fires, count( preg_grep( $matching, $ma->get_tags() ) ) );
+	}
+
+	/**
+	 * @return array {
+	 *     @type string $function Function name.
+	 *     @type int $fires Expected number of hook calls.
+	 *     @type string $matching Regex of hook names to look for.
+	 *     @type array $args Function arguments.
+	 * }
+	 */
+	function data_template_tag_hooks() {
+		return array(
+			array(
+				'wp_seo_the_post_meta_fields',
+				8,
+				'/^wp_seo_post_meta_fields/',
+				array( $this->factory->post->create_and_get() ),
+			),
+			array(
+				'wp_seo_the_add_term_meta_fields',
+				8,
+				'/^wp_seo_add_term_meta_fields/',
+				array( $this->factory->term->create_and_get(), rand_str() ),
+			),
+			array(
+				'wp_seo_the_edit_term_meta_fields',
+				8,
+				'/^wp_seo_edit_term_meta_fields/',
+				array( $this->factory->term->create_and_get(), rand_str() ),
+			),
+		);
+	}
+}

--- a/tests/test-general-functions.php
+++ b/tests/test-general-functions.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Tests for general-functions.php.
+ *
+ * @package WP_SEO
+ */
+
+class WP_SEO_General_Functions_Tests extends WP_UnitTestCase {
+	/**
+	 * Test wp_seo_intersect_args() with args combinations.
+	 *
+	 * @dataProvider data_intersect_args
+	 */
+	function test_intersect_args( $args, $defaults, $expected, $message ) {
+		$this->assertSame(
+			$expected,
+			wp_seo_intersect_args( $args, $defaults ),
+			$message
+		);
+	}
+
+	/**
+	 * @return array {
+	 *     @type array $args User args.
+	 *     @type array $defaults Default args.
+	 *     @type array $expected Expected intersect result.
+	 *     @type array $message Failure message.
+	 * }
+	 */
+	function data_intersect_args() {
+		$key_1 = rand_str();
+		$key_2 = rand_str();
+
+		$val_1 = rand_str();
+		$val_2 = rand_str();
+		$val_3 = rand_str();
+		$val_4 = rand_str();
+
+		return array(
+			array(
+				array(),
+				array( $key_1 => $val_1, $key_2 => $val_2 ),
+				array( $key_1 => $val_1, $key_2 => $val_2 ),
+				'Should return $defaults if no $args are passed'
+			),
+			array(
+				array( $key_1 => $val_3 ),
+				array( $key_1 => $val_1, $key_2 => $val_2 ),
+				array( $key_1 => $val_3, $key_2 => $val_2 ),
+				'Should return any passed $args values whose keys are in $defaults'
+			),
+			array(
+				array( $key_1 => $val_3, $key_2 => $val_4 ),
+				array( $key_1 => $val_1, $key_2 => $val_2 ),
+				array( $key_1 => $val_3, $key_2 => $val_4 ),
+				'Should return all passed $args values whose keys are in $defaults'
+			),
+			array(
+				array( $key_1 => $val_1 ),
+				array( $key_2 => $val_2 ),
+				array( $key_2 => $val_2 ),
+				'Should reject passed $args whose keys are not in defaults'
+			),
+		);
+	}
+}

--- a/tests/test-wp-seo.php
+++ b/tests/test-wp-seo.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Tests for class-wp-seo.php.
+ *
+ * @package WP_SEO
+ */
+class WP_SEO_WP_SEO_Tests extends WP_SEO_Testcase {
+	function test_get_non_term_option() {
+		$this->assertEmpty(
+			WP_SEO::instance()->get_term_option( rand( -1, -100 ), rand_str() ),
+			'Non-existent terms should not return term option data'
+		);
+	}
+
+	function test_get_term_option() {
+		$option_value = rand_str();
+		$term = $this->create_and_get_term_with_option( $option_value );
+		$this->assertSame(
+			WP_SEO::instance()->get_term_option( $term->term_id, $term->taxonomy ),
+			$option_value,
+			'Valid terms with option data should be returned'
+		);
+	}
+
+	function test_intersect_term_option() {
+		$this->assertCount(
+			3,
+			WP_SEO::instance()->intersect_term_option( array() ),
+			'Unexpected term option default key'
+		);
+
+		$this->assertArrayHasKey(
+			'title',
+			WP_SEO::instance()->intersect_term_option( array() ),
+			'Unexpectedly missing default term option key'
+		);
+
+		$this->assertArrayHasKey(
+			'description',
+			WP_SEO::instance()->intersect_term_option( array() ),
+			'Unexpectedly missing default term option key'
+		);
+
+		$this->assertArrayHasKey(
+			'keywords',
+			WP_SEO::instance()->intersect_term_option( array() ),
+			'Unexpectedly missing default term option key'
+		);
+
+	}
+}

--- a/wp-seo.php
+++ b/wp-seo.php
@@ -37,6 +37,18 @@ require_once WP_SEO_PATH . '/php/class-wp-seo-formatting-tag.php';
 // Included formatting tags.
 require_once WP_SEO_PATH . '/php/default-formatting-tags.php';
 
+// General functions.
+require_once WP_SEO_PATH . '/php/general-functions.php';
+
+// Admin-only functions.
+require_once WP_SEO_PATH . '/php/admin-functions.php';
+
+// Admin-only template tags.
+require_once WP_SEO_PATH . '/php/admin-template.php';
+
+// The plugin's default filters.
+require_once WP_SEO_PATH . '/php/default-filters.php';
+
 function wp_seo_admin_scripts() {
 	wp_enqueue_script( 'wp-seo-admin', WP_SEO_URL . 'js/wp-seo.js', array( 'jquery', 'underscore' ), '0.9.0', true );
 	wp_localize_script( 'wp-seo-admin', 'wp_seo_admin', array(

--- a/wp-seo.php
+++ b/wp-seo.php
@@ -25,6 +25,9 @@
 define( 'WP_SEO_PATH', dirname( __FILE__ ) );
 define( 'WP_SEO_URL', trailingslashit( plugins_url( '', __FILE__ ) ) );
 
+// Behind-the-scenes functions.
+require_once WP_SEO_PATH . '/php/internal-functions.php';
+
 // Core filters for the page title and meta tags, and post and term metaboxes.
 require_once WP_SEO_PATH . '/php/class-wp-seo.php';
 
@@ -39,12 +42,6 @@ require_once WP_SEO_PATH . '/php/default-formatting-tags.php';
 
 // General functions.
 require_once WP_SEO_PATH . '/php/general-functions.php';
-
-// Admin-only functions.
-require_once WP_SEO_PATH . '/php/admin-functions.php';
-
-// Admin-only template tags.
-require_once WP_SEO_PATH . '/php/admin-template.php';
 
 // The plugin's default filters.
 require_once WP_SEO_PATH . '/php/default-filters.php';

--- a/wp-seo.php
+++ b/wp-seo.php
@@ -3,7 +3,7 @@
 	Plugin Name: WP SEO
 	Plugin URI: https://github.com/alleyinteractive/wp-seo
 	Description: An SEO plugin that stays out of your way. Just the facts, Jack.
-	Version: 0.9.0
+	Version: 0.11.0
 	Author: Alley Interactive, Matthew Boynes, David Herrera
 	Author URI: http://www.alleyinteractive.com/
 */


### PR DESCRIPTION
From 86ad6e7:

> The default markup for SEO fields for posts and terms isn't always
> appropriate. For example, you might want to provide a "recommended
> character count" in addition to (or instead of) the default character
> count.
> 
> Until now, changing one part of the default markup has required
> overriding a singleton method and replacing all of its content.
> 
> This commit adds hooks, admin template tags, and admin functions that
> allow us to build the default markup incrementally and, in turn,
> customize targeted pieces of it.
> 
> The admin template tags and functions also consolidate bits of logic and
> markup that were previously duplicated across the edit-post, add-term,
> and edit-term screens.
> 
> This commit also adds some general helpers that the new functions use:
> 
> * `wp_seo_intersect_args()`, which is `wp_parse_args()` without allowing
>   you to add keys to the $defaults array.
> * `WP_SEO::get_term_option()`, which gets the term meta option value
>   for a term ID and taxonomy.
> * `WP_SEO::intersect_term_option()`, which normalizes term meta
>   option data via `wp_seo_intersect_args()`.