### PR TITLE
Add "safe mode" for formatting tags

### DIFF
--- a/php/class-wp-seo.php
+++ b/php/class-wp-seo.php
@@ -474,6 +474,8 @@ class WP_SEO {
 	 *
 	 * @access private.
 	 *
+	 * @since 0.12.0 An HTML comment was added to the output.
+	 *
 	 * @param  string $name  The content of the "name" attribute.
 	 * @param  string $content The content of the "content" attribute.
 	 */

--- a/php/class-wp-seo.php
+++ b/php/class-wp-seo.php
@@ -357,13 +357,13 @@ class WP_SEO {
 
 		$raw_string = $string;
 
-		preg_match_all( $this->formatting_tag_pattern, $string, $matches );
-		if ( empty( $matches[0] ) ) {
+		$matches = wp_seo_match_all_formatting_tags( $string );
+		if ( empty( $matches ) ) {
 			return $string;
 		}
 
 		$replacements = array();
-		$unique_matches = array_unique( $matches[0] );
+		$unique_matches = array_unique( $matches );
 
 		foreach( $this->formatting_tags as $id => $tag ) {
 			if ( ! empty( $tag->tag ) && in_array( $tag->tag, $unique_matches ) ) {

--- a/php/formatting-functions.php
+++ b/php/formatting-functions.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Formatting functions.
+ *
+ * @package WP_SEO
+ */
+
+/**
+ * Get each formatting tag in a string.
+ *
+ * @since 0.12.0
+ *
+ * @param string $string String to search.
+ * @return array Array with any found formatting tags. Duplicates are retained.
+ */
+function wp_seo_match_all_formatting_tags( $string ) {
+	preg_match_all( WP_SEO()->formatting_tag_pattern, $string, $matches, PREG_PATTERN_ORDER );
+	return $matches[0];
+}
+
+/**
+ * Reject strings containing formatting tags.
+ *
+ * @since 0.12.0
+ *
+ * @param string $string String to search.
+ * @return string|WP_Error The string, or an error if the string has formatting tags.
+ */
+function wp_seo_no_formatting_tags_allowed( $string ) {
+	$matches = wp_seo_match_all_formatting_tags( $string );
+
+	if ( $matches ) {
+		return new WP_Error( 'has_formatting_tags', __( 'String has formatting tags.', 'wp-seo' ), $matches );
+	}
+
+	return $string;
+}

--- a/php/internal-functions.php
+++ b/php/internal-functions.php
@@ -15,3 +15,12 @@ function wp_seo_load_admin_files() {
 	// Admin-only template tags.
 	require_once WP_SEO_PATH . '/php/admin-template.php';
 }
+
+/**
+ * Add hooks to enable "safe mode" for formatting tags.
+ *
+ * @since 0.12.0
+ */
+function wp_seo_enable_formatting_tag_safe_mode() {
+	add_filter( 'wp_seo_after_format_string', 'wp_seo_no_formatting_tags_allowed' );
+}

--- a/readme.txt
+++ b/readme.txt
@@ -49,7 +49,7 @@ A formatting tag looks like `#site_name#` or `#author#` or `#archive_date#`.
 
 With formatting tags, setting the `<title>` tag format of your date archive to "Time machine set to #archive_date#" would display something like "Time machine set to September 2014" -- and the date would change automatically based on the archive the user looked at.
 
-Some more examples:
+WP SEO comes bundled with many formatting tags. Some more examples:
 
 * If you wanted to include the author name and tags by default in your `<meta>` keywords for all Posts, you could go to "Single Post Defaults" and, under "Meta Keywords Format," use "#author#, #tags#."
 
@@ -75,6 +75,8 @@ These formatting tags are available out-of-the-box:
 * `#term_name#`
 * `#title#`
 
+Any WordPress plugin or theme can register their own tags, too. For example, a social media plugin could add a `#twitter_handle#` formatting tag that displayed a post author's Twitter username.
+
 More details about each tag are available under the "Help" button in the upper-right corner of the settings page.
 
 === Per-entry and per-term fields ===
@@ -95,6 +97,18 @@ Use the "Add another" button to add as many custom `<meta>` tags as you need.
 
 Use the "Remove group" button, or just remove the field content, to remove a custom `<meta>` tag.
 
+== Formatting Tag "Safe Mode" ==
+
+You can enable formatting tag "safe mode" by calling `wp_seo_enable_formatting_tag_safe_mode()` in your plugin or theme. For example: `add_action( 'template_redirect', 'wp_seo_enable_formatting_tag_safe_mode' )`.
+
+"Safe mode" means that WP SEO will not set any `<title>` tags or include any `<meta>` tags that would contain an unrecognized formatting tag.
+
+An "unrecognized" formatting tag could be one with typo, like `#categoories#`. Or it could be a formatting tag from another plugin that was later uninstalled.
+
+When "safe mode" is disabled, WP SEO will include the unrecognized formatting tag in `<title>` or `<meta>` tags as regular text.
+
+"Safe mode" is disabled by default. Which mode to use is up to you. It's easy to spot mistakes when safe mode is disabled, but potentially unhelpful to your site if the mistakes aren't caught.
+
 == Screenshots ==
 
 1. Settings page
@@ -104,6 +118,7 @@ Use the "Remove group" button, or just remove the field content, to remove a cus
 == Changelog ==
 
 = Unreleased =
+* Added: Formatting Tag "Safe Mode" for preventing the display of unrecognized formatting tags.
 * Added: Print an HTML comment next to WP SEO meta tags to help spot them while debugging.
 
 = 0.11.3-beta1 =

--- a/tests/test-formatting-functions.php
+++ b/tests/test-formatting-functions.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Tests for formatting-functions.php.
+ *
+ * @package WP_SEO
+ */
+
+class WP_SEO_Formatting_Functions_Tests extends WP_SEO_Testcase {
+	/**
+	 * Test wp_seo_match_all_formatting_tags() with various strings.
+	 *
+	 * @dataProvider data_match_all_formatting_tags
+	 */
+	function test_match_all_formatting_tags( $string, $expected_count ) {
+		$this->assertCount( $expected_count, wp_seo_match_all_formatting_tags( $string ) );
+	}
+
+	/**
+	 * @return array {
+	 *     @type string String to search.
+	 *     @type int Expected size of the resulting array.
+	 * }
+	 */
+	function data_match_all_formatting_tags() {
+		return array(
+			array( '', 0 ),
+			array( '#title#', 1 ),
+			array( '#title# and #title#', 2 ),
+			array( '#title# and #title# and #description#', 3 ),
+			array( "We're #1!", 0 ),
+		);
+	}
+
+	/**
+	 * Test wp_seo_no_formatting_tags_allowed() with passing strings.
+	 *
+	 * @dataProvider data_no_formatting_tags_allowed_pass
+	 */
+	function test_no_formatting_tags_allowed_pass( $string ) {
+		$this->assertNotWPError( wp_seo_no_formatting_tags_allowed( $string ) );
+	}
+
+	/**
+	 * @return array {
+	 *     @type string The "formatted" string.
+	 * }
+	 */
+	function data_no_formatting_tags_allowed_pass() {
+		return array(
+			array( '' ),
+			array( rand_str() ),
+		);
+	}
+
+	/**
+	 * Test wp_seo_no_formatting_tags_allowed() with failing strings.
+	 *
+	 * @dataProvider data_no_formatting_tags_allowed_fail
+	 */
+	function test_no_formatting_tags_allowed_fail( $string, $data ) {
+		$actual = wp_seo_no_formatting_tags_allowed( $string );
+
+		$this->assertWPError( $actual );
+		$this->assertSame( $data, $actual->get_error_data() );
+	}
+
+	/**
+	 * @return array {
+	 *     @type string The "formatted" string.
+	 *     @type mixed The expected WP_Error::data.
+	 * }
+	 */
+	function data_no_formatting_tags_allowed_fail() {
+		return array(
+			array(
+				rand_str() . ' #title#',
+				array( '#title#' ),
+			),
+		);
+	}
+}

--- a/tests/test-internal-functions.php
+++ b/tests/test-internal-functions.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Tests for internal-functions.php.
+ *
+ * @package WP_SEO
+ */
+
+class WP_SEO_Internal_Functions_Tests extends WP_SEO_Testcase {
+	/**
+	 * Test that enabling formatting-tag safe mode has the expected effects.
+	 */
+	function test_enable_formatting_tag_safe_mode() {
+		$unsafe_string = 'Foo #bar#';
+
+		// Before.
+		$this->assertSame( $unsafe_string, WP_SEO()->format( $unsafe_string ) );
+
+		wp_seo_enable_formatting_tag_safe_mode();
+
+		// After.
+		$this->assertWPError( WP_SEO()->format( $unsafe_string ) );
+	}
+}

--- a/wp-seo.php
+++ b/wp-seo.php
@@ -43,6 +43,9 @@ require_once WP_SEO_PATH . '/php/default-formatting-tags.php';
 // General functions.
 require_once WP_SEO_PATH . '/php/general-functions.php';
 
+// Formatting functions.
+require_once WP_SEO_PATH . '/php/formatting-functions.php';
+
 // The plugin's default filters.
 require_once WP_SEO_PATH . '/php/default-filters.php';
 


### PR DESCRIPTION
Previously discussed in #4 and #12. For details about what this feature does, take a look at c06389f or the changes to README.txt.