### PR TITLE
Coding standards compliance: part 2

### DIFF
--- a/php/class-wp-seo-settings.php
+++ b/php/class-wp-seo-settings.php
@@ -1,8 +1,12 @@
 <?php
 /**
- * WP SEO Settings
+ * Class file for WP_SEO_Settings.
  *
- * @package WP SEO
+ * @package WP_SEO
+ */
+
+/**
+ * Manages the plugin settings page, and provides helpers to some option values.
  */
 class WP_SEO_Settings {
 
@@ -64,23 +68,35 @@ class WP_SEO_Settings {
 	const SLUG = 'wp-seo';
 
 	/**
+	 * Unused.
+	 *
 	 * @codeCoverageIgnore
 	 */
 	private function __construct() {
-		/** Don't do anything, needs to be initialized via instance() method **/
+		// Don't do anything, needs to be initialized via instance() method.
 	}
 
 	/**
+	 * Unused.
+	 *
 	 * @codeCoverageIgnore
 	 */
-	public function __clone() { wp_die( "Please don't __clone WP_SEO_Settings" ); }
+	public function __clone() {
+		wp_die( esc_html__( "Please don't __clone WP_SEO_Settings", 'wp-seo' ) );
+	}
 
 	/**
+	 * Unused.
+	 *
 	 * @codeCoverageIgnore
 	 */
-	public function __wakeup() { wp_die( "Please don't __wakeup WP_SEO_Settings" ); }
+	public function __wakeup() {
+		wp_die( esc_html__( "Please don't __wakeup WP_SEO_Settings", 'wp-seo' ) );
+	}
 
 	/**
+	 * Get the instance of this class.
+	 *
 	 * @codeCoverageIgnore
 	 */
 	public static function instance() {
@@ -159,8 +175,8 @@ class WP_SEO_Settings {
 	/**
 	 * Get an option value.
 	 *
-	 * @param  string $key The option key sought.
-	 * @param  mixed $default Optional default.
+	 * @param string $key     The option key sought.
+	 * @param mixed  $default Optional default.
 	 * @return mixed The value, or null on failure.
 	 */
 	public function get_option( $key, $default = null ) {
@@ -218,8 +234,8 @@ class WP_SEO_Settings {
 	/**
 	 * Helper to check whether a post type is set in "Add fields to individual."
 	 *
-	 * @param  string  $post_type Post type name.
-	 * @return boolean
+	 * @param string $post_type Post type name.
+	 * @return bool
 	 */
 	public function has_post_fields( $post_type ) {
 		return in_array( $post_type, $this->get_enabled_post_types() );
@@ -228,8 +244,8 @@ class WP_SEO_Settings {
 	/**
 	 * Helper to check whether a taxonomy is set in "Add fields to individual."
 	 *
-	 * @param  string $taxonomy Taxonomy name
-	 * @return boolean
+	 * @param string $taxonomy Taxonomy name.
+	 * @return bool
 	 */
 	public function has_term_fields( $taxonomy ) {
 		return in_array( $taxonomy, $this->get_enabled_taxonomies() );
@@ -267,7 +283,7 @@ class WP_SEO_Settings {
 		add_settings_section( 'post_types', __( 'Post Types', 'wp-seo' ), '__return_false', $this::SLUG );
 		add_settings_field( 'post_types', __( 'Add SEO fields to individual:', 'wp-seo' ), array( $this, 'field' ), $this::SLUG, 'post_types', array( 'field' => 'post_types', 'type' => 'checkboxes', 'boxes' => call_user_func_array( 'wp_list_pluck', array( $this->single_post_types, 'label' ) ) ) );
 
-		foreach( $this->single_post_types as $post_type ) {
+		foreach ( $this->single_post_types as $post_type ) {
 			/* translators: %s: post type singular name */
 			add_settings_section( 'single_' . $post_type->name, sprintf( __( 'Single %s Defaults', 'wp-seo' ), $post_type->labels->singular_name ), array( $this, 'example_permalink' ), $this::SLUG );
 			add_settings_field( "single_{$post_type->name}_title", __( 'Title Tag Format', 'wp-seo' ), array( $this, 'field' ), $this::SLUG, 'single_' . $post_type->name, array( 'field' => "single_{$post_type->name}_title" ) );
@@ -275,7 +291,7 @@ class WP_SEO_Settings {
 			add_settings_field( "single_{$post_type->name}_keywords", __( 'Meta Keywords Format', 'wp-seo' ), array( $this, 'field' ), $this::SLUG, 'single_' . $post_type->name, array( 'field' => "single_{$post_type->name}_keywords" ) );
 		}
 
-		foreach( $this->archived_post_types as $post_type ) {
+		foreach ( $this->archived_post_types as $post_type ) {
 			/* translators: %s: post type singular name */
 			add_settings_section( 'archive_' . $post_type->name, sprintf( __( '%s Archives', 'wp-seo' ), $post_type->labels->singular_name ), array( $this, 'example_post_type_archive' ), $this::SLUG );
 			add_settings_field( "archive_{$post_type->name}_title", __( 'Title Tag Format', 'wp-seo' ), array( $this, 'field' ), $this::SLUG, 'archive_' . $post_type->name, array( 'field' => "archive_{$post_type->name}_title" ) );
@@ -287,7 +303,7 @@ class WP_SEO_Settings {
 		add_settings_section( 'taxonomies', __( 'Taxonomies', 'wp-seo' ), '__return_false', $this::SLUG );
 		add_settings_field( 'taxonomies', __( 'Add SEO fields to individual:', 'wp-seo' ), array( $this, 'field' ), $this::SLUG, 'taxonomies', array( 'field' => 'taxonomies', 'type' => 'checkboxes', 'boxes' => call_user_func_array( 'wp_list_pluck', array( array_diff_key( $this->taxonomies, array( 'post_format' => true ) ), 'label' ) ) ) );
 
-		foreach( $this->taxonomies as $taxonomy ) {
+		foreach ( $this->taxonomies as $taxonomy ) {
 			/* translators: %s: taxonomy singular name */
 			add_settings_section( 'archive_' . $taxonomy->name, sprintf( __( '%s Archives', 'wp-seo' ), $taxonomy->labels->singular_name ), array( $this, 'example_term_archive' ), $this::SLUG );
 			add_settings_field( "archive_{$taxonomy->name}_title", __( 'Title Tag Format', 'wp-seo' ), array( $this, 'field' ), $this::SLUG, 'archive_' . $taxonomy->name, array( 'field' => "archive_{$taxonomy->name}_title" ) );
@@ -332,8 +348,8 @@ class WP_SEO_Settings {
 	 * For showing an example of a URL on which a group of SEO fields applies
 	 * or indicating that the fields don't apply anywhere yet.
 	 *
-	 * @param  string  $text		The text to show before the URL.
-	 * @param  bool|string $url 	The URL to show, or false if none exists.
+	 * @param string      $text The text to show before the URL.
+	 * @param bool|string $url  The URL to show, or false if none exists.
 	 */
 	public function example_url( $text, $url = false ) {
 		echo '<p class="description">' . esc_html( $text );
@@ -465,14 +481,14 @@ class WP_SEO_Settings {
 	/**
 	 * Render a settings text field.
 	 *
-	 * @param  array $args {
+	 * @param array  $args {
 	 *     An array of arguments for the text field.
 	 *
 	 *     @type string $field  The field name.
 	 *     @type string $type   The field type. Default 'text'.
 	 *     @type string $size   The field size. Default 80.
 	 * }
-	 * @param  string $value	The current field value.
+	 * @param string $value The current field value.
 	 */
 	public function render_text_field( $args, $value ) {
 		$args = wp_parse_args( $args, array(
@@ -493,14 +509,14 @@ class WP_SEO_Settings {
 	/**
 	 * Render a settings textarea.
 	 *
-	 * @param  array $args {
+	 * @param array  $args {
 	 *     An array of arguments for the textarea.
 	 *
 	 *     @type  string $field The field name.
 	 *     @type  int    $rows  Rows in the textarea. Default 2.
 	 *     @type  int    $cols  Columns in the textarea. Default 80.
 	 * }
-	 * @param  string $value	The current field value.
+	 * @param string $value The current field value.
 	 */
 	public function render_textarea( $args, $value ) {
 		$args = wp_parse_args( $args, array(
@@ -531,7 +547,7 @@ class WP_SEO_Settings {
 	 * @param  array $values Indexed array of current field values.
 	 */
 	public function render_checkboxes( $args, $values ) {
-		foreach( $args['boxes'] as $box_value => $box_label ) {
+		foreach ( $args['boxes'] as $box_value => $box_label ) {
 			printf( '
 					<label for="%1$s_%2$s_%3$s">
 						<input id="%1$s_%2$s_%3$s" type="checkbox" name="%1$s[%2$s][]" value="%3$s" %4$s>
@@ -557,28 +573,27 @@ class WP_SEO_Settings {
 	 *                          include in each repeated instance of the field.
 	 *     @type string $size   Optional. The field size. Default 70.
 	 * }
-	 * @param  array $value The current field values
+	 * @param  array $values The current field values.
 	 */
 	public function render_repeatable_field( $args, $values ) {
 		$args = wp_parse_args( $args, array(
 			'size' => 70,
 		) );
-		$input_string = '
-			<label for="%1$s_%2$s_%3$s_%4$s">
-				%5$s
-			</label>
-			<input class="repeatable" type="text" id="%1$s_%2$s_%3$s_%4$s" name="%1$s[%2$s][%3$s][%4$s]" size="%6$s" value="%7$s" />';
 		$data_start = ( 0 === count( $values ) ) ? 1 : count( $values );
 		?>
 			<div class="wp-seo-repeatable">
 				<div class="nodes">
 					<?php if ( ! empty( $values ) ) : ?>
-						<?php foreach( (array) $values as $i => $group ) : ?>
+						<?php foreach ( (array) $values as $i => $group ) : ?>
 							<div class="wp-seo-repeatable-group">
-								<?php foreach( $group as $name => $value ) : ?>
+								<?php foreach ( $group as $name => $value ) : ?>
 									<div class="wp-seo-repeatable-field">
 										<?php
-											printf( $input_string,
+											printf( '
+												<label for="%1$s_%2$s_%3$s_%4$s">
+													%5$s
+												</label>
+												<input class="repeatable" type="text" id="%1$s_%2$s_%3$s_%4$s" name="%1$s[%2$s][%3$s][%4$s]" size="%6$s" value="%7$s" />',
 												esc_attr( $this::SLUG ),
 												esc_attr( $args['field'] ),
 												intval( $i ),
@@ -594,10 +609,14 @@ class WP_SEO_Settings {
 						<?php endforeach; ?>
 					<?php else : ?>
 						<div class="wp-seo-repeatable-group">
-							<?php foreach( $args['repeat'] as $name => $label ) : ?>
+							<?php foreach ( $args['repeat'] as $name => $label ) : ?>
 								<div class="wp-seo-repeatable-field">
 									<?php
-										printf( $input_string,
+										printf( '
+											<label for="%1$s_%2$s_%3$s_%4$s">
+												%5$s
+											</label>
+											<input class="repeatable" type="text" id="%1$s_%2$s_%3$s_%4$s" name="%1$s[%2$s][%3$s][%4$s]" size="%6$s" value="%7$s" />',
 											esc_attr( $this::SLUG ),
 											esc_attr( $args['field'] ),
 											0,
@@ -615,10 +634,14 @@ class WP_SEO_Settings {
 
 				<script type="text/template" class="wp-seo-template" data-start="<?php echo absint( $data_start ); ?>">
 					<div class="wp-seo-repeatable-group">
-						<?php foreach( $args['repeat'] as $name => $label ) : ?>
+						<?php foreach ( $args['repeat'] as $name => $label ) : ?>
 							<div class="wp-seo-repeatable-field">
 								<?php
-									printf( $input_string,
+									printf( '
+										<label for="%1$s_%2$s_%3$s_%4$s">
+											%5$s
+										</label>
+										<input class="repeatable" type="text" id="%1$s_%2$s_%3$s_%4$s" name="%1$s[%2$s][%3$s][%4$s]" size="%6$s" value="%7$s" />',
 										esc_attr( $this::SLUG ),
 										esc_attr( $args['field'] ),
 										'<%= i %>',
@@ -647,20 +670,20 @@ class WP_SEO_Settings {
 				<form action="options.php" method="POST">
 					<?php settings_fields( $this::SLUG ); ?>
 					<?php
-						/**
-						 * Filter the type of UI to use with settings sections.
-						 *
-						 * @param  bool Whether to enhance the page with accordions.
-						 */
-						if ( apply_filters( 'wp_seo_use_settings_accordions', true ) ) {
-							global $wp_settings_sections;
-							foreach ( (array) $wp_settings_sections[ $this::SLUG ] as $section ) {
-								add_meta_box( $section['id'], $section['title'], array( $this, 'settings_meta_box' ), 'wp-seo', 'advanced', 'default', $section );
-							}
-							do_accordion_sections( 'wp-seo', 'advanced', null );
-						} else {
-							do_settings_sections( $this::SLUG );
+					/**
+					 * Filter the type of UI to use with settings sections.
+					 *
+					 * @param  bool Whether to enhance the page with accordions.
+					 */
+					if ( apply_filters( 'wp_seo_use_settings_accordions', true ) ) {
+						global $wp_settings_sections;
+						foreach ( (array) $wp_settings_sections[ $this::SLUG ] as $section ) {
+							add_meta_box( $section['id'], $section['title'], array( $this, 'settings_meta_box' ), 'wp-seo', 'advanced', 'default', $section );
 						}
+						do_accordion_sections( 'wp-seo', 'advanced', null );
+					} else {
+						do_settings_sections( $this::SLUG );
+					}
 					?>
 					<?php submit_button(); ?>
 				</form>
@@ -708,20 +731,20 @@ class WP_SEO_Settings {
 		 * Sanitize these as text fields and in the following order:
 		 */
 
-		// Home description and keywords
+		// Home description and keywords.
 		$sanitize_as_text_field = array(
 			'home_title',
 			'home_description',
 			'home_keywords',
 		);
 		// Single post default formats.
-		foreach( $this->single_post_types as $type ) {
+		foreach ( $this->single_post_types as $type ) {
 			$sanitize_as_text_field[] = "single_{$type->name}_title";
 			$sanitize_as_text_field[] = "single_{$type->name}_description";
 			$sanitize_as_text_field[] = "single_{$type->name}_keywords";
 		}
-		// Post type and taxonomy archives, and "Other Archive Types."
-		foreach( array_merge( $this->archived_post_types, $this->taxonomies, array( 'author', 'date' ) ) as $type ) {
+		// Post type, taxonomy, and other archives.
+		foreach ( array_merge( $this->archived_post_types, $this->taxonomies, array( 'author', 'date' ) ) as $type ) {
 			if ( is_object( $type ) ) {
 				$type = $type->name;
 			}
@@ -733,7 +756,7 @@ class WP_SEO_Settings {
 		$sanitize_as_text_field[] = 'search_title';
 		$sanitize_as_text_field[] = '404_title';
 
-		foreach( $sanitize_as_text_field as $field ) {
+		foreach ( $sanitize_as_text_field as $field ) {
 			$out[ $field ] = isset( $in[ $field ] ) && is_string( $in[ $field ] ) ? sanitize_text_field( $in[ $field ] ) : null;
 		}
 
@@ -748,8 +771,8 @@ class WP_SEO_Settings {
 		foreach ( $repeatables as $repeatable => $fields ) {
 			$out[ $repeatable ] = array();
 			if ( isset( $in[ $repeatable ] ) ) {
-				foreach( array_values( $in[ $repeatable ] ) as $i => $group ) {
-					foreach( $fields as $field ) {
+				foreach ( array_values( $in[ $repeatable ] ) as $i => $group ) {
+					foreach ( $fields as $field ) {
 						$out[ $repeatable ][ $i ][ $field ] = isset( $group[ $field ] ) ? sanitize_text_field( $group[ $field ] ) : null;
 					}
 					// Remove empty values from this group of fields.
@@ -776,7 +799,7 @@ class WP_SEO_Settings {
 			<aside>
 				<h1><?php esc_html_e( 'These Formatting Tags are available', 'wp-seo' ); ?></h1>
 				<dl class="formatting-tags">
-					<?php foreach( $formatting_tags as $tag ) : ?>
+					<?php foreach ( $formatting_tags as $tag ) : ?>
 						<div class="formatting-tag-wrapper">
 							<dt class="formatting-tag-name"><?php echo esc_html( $tag->tag ); ?></dt>
 							<dd class="formatting-tag-description"><?php echo esc_html( $tag->get_description() ); ?></dd>
@@ -795,7 +818,7 @@ class WP_SEO_Settings {
  *
  * @return object
  */
-function WP_SEO_Settings() {
+function wp_seo_settings() {
 	return WP_SEO_Settings::instance();
 }
 add_action( 'after_setup_theme', 'WP_SEO_Settings', 9 );

--- a/php/class-wp-seo.php
+++ b/php/class-wp-seo.php
@@ -1,581 +1,580 @@
 <?php
 if ( ! class_exists( 'WP_SEO' ) ) :
-/**
- * WP SEO Core Functionality
- *
- * @package WP SEO
- */
-class WP_SEO {
-
 	/**
-	 * Instance of this class.
+	 * WP SEO Core Functionality
 	 *
-	 * @var object
+	 * @package WP SEO
 	 */
-	private static $instance = null;
+	class WP_SEO {
 
-	/**
-	 * Associative array of WP_SEO_Formatting_Tag instances.
-	 *
-	 * @var array.
-	 */
-	public $formatting_tags = array();
-
-	/**
-	 * The regular expression used to find formatting tags.
-	 *
-	 * @var string.
-	 */
-	public $formatting_tag_pattern = '';
-
-	/**
-	 * @codeCoverageIgnore
-	 */
-	private function __construct() {
-		/* Don't do anything, needs to be initialized via instance() method */
-	}
-
-	/**
-	 * @codeCoverageIgnore
-	 */
-	public function __clone() { wp_die( __( "Please don't __clone WP_SEO", "wp-seo" ) ); }
-
-	/**
-	 * @codeCoverageIgnore
-	 */
-	public function __wakeup() { wp_die( __( "Please don't __wakeup WP_SEO", "wp-seo" ) ); }
-
-	/**
-	 * @codeCoverageIgnore
-	 */
-	public static function instance() {
-		if ( ! isset( self::$instance ) ) {
-			self::$instance = new WP_SEO;
-			self::$instance->setup();
-		}
-		return self::$instance;
-	}
-
-	/**
-	 * Add actions and filters.
-	 *
-	 * @codeCoverageIgnore
-	 */
-	protected function setup() {
-		add_action( 'wp_loaded', array( $this, 'set_properties' ) );
-
-		if ( is_admin() ) {
-			add_action( 'add_meta_boxes', array( $this, 'add_meta_boxes' ) );
-			add_action( 'save_post', array( $this, 'save_post_fields' ) );
-			add_action( 'edit_attachment', array( $this, 'save_post_fields' ) );
-			add_action( 'add_attachment', array( $this, 'save_post_fields' ) );
-			add_action( 'admin_init', array( $this, 'add_term_boxes' ) );
-		}
-
-		add_filter( 'pre_get_document_title', array( $this, 'pre_get_document_title' ), 20 );
-		add_filter( 'wp_title', array( $this, 'wp_title' ), 20, 2 );
-		add_filter( 'wp_head', array( $this, 'wp_head' ), 5 );
-	}
-
-	/**
-	 * Set class properties.
-	 *
-	 * The filter for adding custom formatting tags is applied here.
-	 */
-	public function set_properties() {
-		$tags = array();
 		/**
-		 * Filter the available formatting tags.
+		 * Instance of this class.
 		 *
-		 * @see wp_seo_default_formatting_tags() for an example implementation.
-		 *
-		 * @param array $tags Associative array of WP_SEO_Formatting_Tag instances.
+		 * @var object
 		 */
-		foreach ( apply_filters( 'wp_seo_formatting_tags', $tags ) as $id => $tag ) {
-			if ( is_a( $tag, 'WP_SEO_Formatting_Tag' ) ) {
-				$tags[ $id ] = $tag;
+		private static $instance = null;
+
+		/**
+		 * Associative array of WP_SEO_Formatting_Tag instances.
+		 *
+		 * @var array.
+		 */
+		public $formatting_tags = array();
+
+		/**
+		 * The regular expression used to find formatting tags.
+		 *
+		 * @var string.
+		 */
+		public $formatting_tag_pattern = '';
+
+		/**
+		 * @codeCoverageIgnore
+		 */
+		private function __construct() {
+			/* Don't do anything, needs to be initialized via instance() method */
+		}
+
+		/**
+		 * @codeCoverageIgnore
+		 */
+		public function __clone() { wp_die( __( "Please don't __clone WP_SEO", "wp-seo" ) ); }
+
+		/**
+		 * @codeCoverageIgnore
+		 */
+		public function __wakeup() { wp_die( __( "Please don't __wakeup WP_SEO", "wp-seo" ) ); }
+
+		/**
+		 * @codeCoverageIgnore
+		 */
+		public static function instance() {
+			if ( ! isset( self::$instance ) ) {
+				self::$instance = new WP_SEO;
+				self::$instance->setup();
 			}
+			return self::$instance;
 		}
-		$this->formatting_tags = $tags;
 
 		/**
-		 * Filter the regular expression used to find formatting tags.
+		 * Add actions and filters.
 		 *
-		 * You might need this if you want to add unusual custom tags.
-		 *
-		 * @param string WP_SEO::formatting_tag_pattern The regex.
+		 * @codeCoverageIgnore
 		 */
-		$this->formatting_tag_pattern = apply_filters( 'wp_seo_formatting_tag_pattern', '/#[a-zA-Z\_]+#/' );
-	}
+		protected function setup() {
+			add_action( 'wp_loaded', array( $this, 'set_properties' ) );
 
-	/**
-	 * Get the WP SEO term option value for a given term.
-	 *
-	 * @param int $term_id Term ID.
-	 * @param string $taxonomy Term taxonomy.
-	 * @return mixed The get_option() return value for the given term data.
-	 */
-	public function get_term_option( $term_id, $taxonomy ) {
-		$option_name = '';
-
-		$term = get_term( $term_id, $taxonomy );
-
-		if ( $term instanceof \WP_Term ) {
-			$option_name = $this->get_term_option_name( $term );
-		}
-
-		return get_option( $option_name );
-	}
-
-	/**
-	 * Intersect data with the default array of WP SEO term option values.
-	 *
-	 * @param array $option_value Array of term SEO option values, if any.
-	 * @return array Option values with default keys and values.
-	 */
-	public function intersect_term_option( $option_value ) {
-		return wp_seo_intersect_args( $option_value, array(
-			'title'       => '',
-			'description' => '',
-			'keywords'    => '',
-		) );
-	}
-
-	/**
-	 * Add the SEO fields to post types that support them.
-	 *
-	 * @param string $post_type The current post type.
-	 */
-	public function add_meta_boxes( $post_type ) {
-		if ( WP_SEO_Settings()->has_post_fields( $post_type ) ) {
-			add_meta_box(
-				'wp_seo',
-				wp_seo_get_box_title(),
-				array( $this, 'post_meta_fields' ),
-				$post_type,
-				/**
-				 * Filter the screen context where the fields should display.
-				 *
-				 * @param  string @see add_meta_box().
-				 */
-				apply_filters( 'wp_seo_meta_box_context', 'normal' ),
-				/**
-				 * Filter the display priority of the fields within the context.
-				 *
-				 * @param  string @see add_meta_box().
-				 */
-				apply_filters( 'wp_seo_meta_box_priority', 'high' )
-			);
-		}
-	}
-
-	/**
-	 * Display the SEO fields for a post.
-	 *
-	 * @param  WP_Post $post The post being edited.
-	 */
-	public function post_meta_fields( $post ) {
-		wp_nonce_field( plugin_basename( __FILE__ ), 'wp-seo-nonce' );
-
-		/**
-		 * Fires during the WP SEO post meta box display callback.
-		 *
-		 * @param WP_Post $post The post passed to the meta box display callback.
-		 */
-		do_action( 'wp_seo_post_meta_fields', $post );
-	}
-
-	/**
-	 * Save the SEO values as post meta.
-	 *
-	 * @param  int $post_id The post ID being edited.
-	 */
-	public function save_post_fields( $post_id ) {
-		if ( ! isset( $_POST['post_type'] ) ) {
-			return;
-		}
-
-		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
-			return;
-		}
-
-		if ( ! WP_SEO_Settings()->has_post_fields( $_POST['post_type'] ) ) {
-			return;
-		}
-
-		$post_type = get_post_type_object( $_POST['post_type'] );
-		if ( empty( $post_type->cap->edit_post ) || ! current_user_can( $post_type->cap->edit_post, $post_id ) ) {
-			return;
-		}
-
-		if ( ! isset( $_POST['wp-seo-nonce'] ) ) {
-			return;
-		}
-
-		if ( ! wp_verify_nonce( $_POST['wp-seo-nonce'], plugin_basename( __FILE__ ) ) ) {
-			return;
-		}
-
-		if ( ! isset( $_POST['post_ID'] ) ) {
-			return;
-		}
-
-		$post_id = absint( $_POST['post_ID'] );
-
-		if ( ! isset( $_POST['seo_meta'] ) ) {
-			$_POST['seo_meta'] = array();
-		}
-
-		foreach ( array( 'title', 'description', 'keywords' ) as $field ) {
-			$data = isset( $_POST['seo_meta'][ $field ] ) ? sanitize_text_field( $_POST['seo_meta'][ $field ] ) : '';
-			update_post_meta( $post_id, '_meta_' . $field, $data );
-		}
-	}
-
-	/**
-	 * Add the meta box to taxonomies with per-term fields enabled.
-	 */
-	public function add_term_boxes() {
-		foreach ( WP_SEO_Settings()->get_enabled_taxonomies() as $slug ) {
-			add_action( $slug . '_add_form_fields', array( $this, 'add_term_meta_fields' ) );
-			add_action( $slug . '_edit_form', array( $this, 'edit_term_meta_fields' ), 10, 2 );
-		}
-		add_action( 'created_term', array( $this, 'save_term_fields' ), 10, 3 );
-		add_action( 'edited_term', array( $this, 'save_term_fields' ), 10, 3 );
-	}
-
-	/**
-	 * Helper to construct an option name for per-term SEO fields.
-	 *
-	 * @param  object $term The term object
-	 * @return string The option name
-	 */
-	public function get_term_option_name( $term ) {
-		return "wp-seo-term-{$term->term_taxonomy_id}";
-	}
-
-	/**
-	 * Display the SEO fields for adding a term.
-	 *
-	 * @param string $taxonomy The taxonomy slug.
-	 */
-	public function add_term_meta_fields( $taxonomy ) {
-		wp_nonce_field( plugin_basename( __FILE__ ), 'wp-seo-nonce' );
-
-		/**
-		 * Fires during the WP SEO add-term fields display callback.
-		 *
-		 * @param string $taxonomy The taxonomy slug.
-		 */
-		do_action( 'wp_seo_add_term_meta_fields', $taxonomy );
-	}
-
-	/**
-	 * Display the SEO fields for editing a term.
-	 *
-	 * @param  object $tag The term object
-	 * @param  string $taxonomy The taxonomy slug
-	 */
-	public function edit_term_meta_fields( $tag, $taxonomy ) {
-		wp_nonce_field( plugin_basename( __FILE__ ), 'wp-seo-nonce' );
-
-		/**
-		 * Fires during the WP SEO edit-term fields display callback.
-		 *
-		 * @param WP_Term $tag The term object.
-		 * @param string $taxonomy The taxonomy slug.
-		 */
-		do_action( 'wp_seo_edit_term_meta_fields', $tag, $taxonomy );
-	}
-
-	/**
-	 * Save the SEO term values as an option.
-	 *
-	 * @see wp_unslash(), which the Settings API and update_post_meta()
-	 *     otherwise handle.
-	 *
-	 * @param  int $term_id Term ID.
-	 * @param  int $tt_id Term taxonomy ID.
-	 * @param  string $taxonomy Taxonomy slug.
-	 */
-	public function save_term_fields( $term_id, $tt_id, $taxonomy ) {
-		if ( ! isset( $_POST['taxonomy'] ) ) {
-			return;
-		}
-
-		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
-			return;
-		}
-
-		if ( ! WP_SEO_Settings()->has_term_fields( $taxonomy ) ) {
-			return;
-		}
-
-		$object = get_taxonomy( $taxonomy );
-		if ( empty( $object->cap->edit_terms ) || ! current_user_can( $object->cap->edit_terms ) ) {
-			return;
-		}
-
-		if ( ! isset( $_POST['wp-seo-nonce'] ) ) {
-			return;
-		}
-
-		if ( ! wp_verify_nonce( $_POST['wp-seo-nonce'], plugin_basename( __FILE__ ) ) ) {
-			return;
-		}
-
-		if ( ! isset( $_POST['seo_meta'] ) ) {
-			$_POST['seo_meta'] = array();
-		}
-
-		foreach ( array( 'title', 'description', 'keywords' ) as $field ) {
-			$data[ $field ] = isset( $_POST['seo_meta'][ $field ] ) ? sanitize_text_field( wp_unslash( $_POST['seo_meta'][ $field ] ) ) : '';
-		}
-
-		$name = $this->get_term_option_name( get_term( $term_id, $taxonomy ) );
-		if ( false === get_option( $name ) ) {
-			// Don't create an option unless at least one field exists.
-			$filtered_data = array_filter( $data );
-			if ( ! empty( $filtered_data ) ) {
-				add_option( $name, $data, null, false );
+			if ( is_admin() ) {
+				add_action( 'add_meta_boxes', array( $this, 'add_meta_boxes' ) );
+				add_action( 'save_post', array( $this, 'save_post_fields' ) );
+				add_action( 'edit_attachment', array( $this, 'save_post_fields' ) );
+				add_action( 'add_attachment', array( $this, 'save_post_fields' ) );
+				add_action( 'admin_init', array( $this, 'add_term_boxes' ) );
 			}
-		} else {
-			update_option( $name, $data );
-		}
-	}
 
-	/**
-	 * Replace formatting tags in a string with their value for the current page.
-	 *
-	 * @param  string $string  The string with formatting tags.
-	 * @return string|WP_Error The formatted string, or WP_Error on error.
-	 */
-	public function format( $string ) {
-		if ( ! is_string( $string ) ) {
-			return new WP_Error( 'format_error', __( "Please don't try to format() a non-string.", 'wp-seo' ) );
-		}
-
-		$raw_string = $string;
-
-		$matches = wp_seo_match_all_formatting_tags( $string );
-		if ( empty( $matches ) ) {
-			return $string;
-		}
-
-		$replacements = array();
-		$unique_matches = array_unique( $matches );
-
-		foreach( $this->formatting_tags as $id => $tag ) {
-			if ( ! empty( $tag->tag ) && in_array( $tag->tag, $unique_matches ) ) {
-				/**
-				 * Filter the value of a formatting tag for the current page.
-				 *
-				 * The dynamic portion of the hook name, $id, refers to the key
-				 * used to register the tag in WP_SEO::set_properties(). For
-				 * example, the hook for the default "#site_name#" formatting
-				 * tag is 'wp_seo_format_site_name'.
-				 *
-				 * @see wp_seo_default_formatting_tags() for the defaults' keys.
-				 *
-				 * @param  string The value returned by the formatting tag.
-				 */
-				$replacements[ $tag->tag ] = apply_filters( "wp_seo_format_{$id}", $tag->get_value() );
-			}
-		}
-
-		if ( ! empty( $replacements ) ) {
-			$string = str_replace( array_keys( $replacements ), array_values( $replacements ), $string );
+			add_filter( 'pre_get_document_title', array( $this, 'pre_get_document_title' ), 20 );
+			add_filter( 'wp_title', array( $this, 'wp_title' ), 20, 2 );
+			add_filter( 'wp_head', array( $this, 'wp_head' ), 5 );
 		}
 
 		/**
-		 * Filter the formatted string.
+		 * Set class properties.
 		 *
-		 * @param  string $string 		The formatted string.
-		 * @param  string $raw_string 	The string as submitted.
+		 * The filter for adding custom formatting tags is applied here.
 		 */
-		return apply_filters( 'wp_seo_after_format_string', $string, $raw_string );
-	}
-
-	/**
-	 * Filter the page title with the custom title or formatted title.
-	 *
-	 * @param  string $title The page title from wp_title().
-	 * @param  string $sep   The title separator.
-	 * @return string        The custom title of the current entry, if one
-	 *                       exists, or the formatted title from the settings
-	 *                       for the current post type. The original title if no
-	 *                       custom or formatted title exists.
-	 */
-	public function wp_title( $title, $sep ) {
-		if ( is_singular() ) {
-			if ( WP_SEO_Settings()->has_post_fields( $post_type = get_post_type() ) && $meta_title = get_post_meta( get_the_ID(), '_meta_title', true ) ) {
-				return $meta_title;
-			} else {
-				$key = "single_{$post_type}_title";
-			}
-		} elseif ( is_front_page() ) {
-			$key = 'home_title';
-		} elseif ( is_author() ) {
-			$key = 'archive_author_title';
-		} elseif ( is_category() || is_tag() || is_tax() ) {
-			if ( ( WP_SEO_Settings()->has_term_fields( $taxonomy = get_queried_object()->taxonomy ) ) && ( $option = get_option( $this->get_term_option_name( get_queried_object() ) ) ) && ( ! empty( $option['title'] ) ) ) {
-				return $option['title'];
-			} else {
-				$key = "archive_{$taxonomy}_title";
-			}
-		} elseif ( is_post_type_archive() ) {
-			$key = 'archive_' . get_queried_object()->name . '_title';
-		} elseif ( is_date() ) {
-			$key = 'archive_date_title';
-		} elseif ( is_search() ) {
-			$key = 'search_title';
-		} elseif ( is_404() ) {
-			$key = '404_title';
-		} else {
-			$key = false;
-		}
-
-		if ( $key ) {
+		public function set_properties() {
+			$tags = array();
 			/**
-			 * Filter the format string of the title tag for the current page.
+			 * Filter the available formatting tags.
 			 *
-			 * @param  string		The format string retrieved from the settings.
-			 * @param  string $key 	The key of the setting retrieved.
+			 * @see wp_seo_default_formatting_tags() for an example implementation.
+			 *
+			 * @param array $tags Associative array of WP_SEO_Formatting_Tag instances.
 			 */
-			$title_string = apply_filters( 'wp_seo_title_tag_format', WP_SEO_Settings()->get_option( $key ), $key );
-			$title_tag = $this->format( $title_string );
-			if ( $title_tag && ! is_wp_error( $title_tag ) ) {
-				$title = $title_tag;
+			foreach ( apply_filters( 'wp_seo_formatting_tags', $tags ) as $id => $tag ) {
+				if ( is_a( $tag, 'WP_SEO_Formatting_Tag' ) ) {
+					$tags[ $id ] = $tag;
+				}
 			}
+			$this->formatting_tags = $tags;
+
+			/**
+			 * Filter the regular expression used to find formatting tags.
+			 *
+			 * You might need this if you want to add unusual custom tags.
+			 *
+			 * @param string WP_SEO::formatting_tag_pattern The regex.
+			 */
+			$this->formatting_tag_pattern = apply_filters( 'wp_seo_formatting_tag_pattern', '/#[a-zA-Z\_]+#/' );
 		}
 
-		return $title;
-	}
+		/**
+		 * Get the WP SEO term option value for a given term.
+		 *
+		 * @param int $term_id Term ID.
+		 * @param string $taxonomy Term taxonomy.
+		 * @return mixed The get_option() return value for the given term data.
+		 */
+		public function get_term_option( $term_id, $taxonomy ) {
+			$option_name = '';
 
-	/**
-	 * Filter the document title before it is generated.
-	 *
-	 * @param string $title The document title. Default empty string.
-	 * @return string The custom title, if any, or the received $title if none exists.
-	 */
-	public function pre_get_document_title( $title ) {
-		// We can lean on the logic already in WP_SEO::wp_title().
-		$custom = $this->wp_title( $title, '' );
+			$term = get_term( $term_id, $taxonomy );
 
-		if ( $custom ) {
-			$title = $custom;
+			if ( $term instanceof \WP_Term ) {
+				$option_name = $this->get_term_option_name( $term );
+			}
+
+			return get_option( $option_name );
 		}
 
-		return $title;
-	}
-
-	/**
-	 * Render a <meta /> field.
-	 *
-	 * @access private.
-	 *
-	 * @since 0.12.0 An HTML comment was added to the output.
-	 *
-	 * @param  string $name  The content of the "name" attribute.
-	 * @param  string $content The content of the "content" attribute.
-	 */
-	private function meta_field( $name, $content ) {
-		if ( ! is_string( $name ) || ! is_string( $content ) ) {
-			return;
+		/**
+		 * Intersect data with the default array of WP SEO term option values.
+		 *
+		 * @param array $option_value Array of term SEO option values, if any.
+		 * @return array Option values with default keys and values.
+		 */
+		public function intersect_term_option( $option_value ) {
+			return wp_seo_intersect_args( $option_value, array(
+				'title'       => '',
+				'description' => '',
+				'keywords'    => '',
+			) );
 		}
 
-		echo "<meta name='" . esc_attr( $name ) . "' content='" . esc_attr( $content ) . "' /><!-- WP SEO -->\n";
-	}
-
-	/**
-	 * Determine the <meta> values for the current page.
-	 *
-	 * Unlike WP_SEO::wp_title(), custom per-entry and per-term values are not
-	 * returned immediately but rendered at the end of the method.
-	 *
-	 * @see WP_SEO::meta_field() for detail on how the values are rendered.
-	 */
-	public function wp_head() {
-		if ( is_singular() ) {
-			if ( WP_SEO_Settings()->has_post_fields( $post_type = get_post_type() ) ) {
-				$meta_description = get_post_meta( get_the_ID(), '_meta_description', true );
-				$meta_keywords = get_post_meta( get_the_ID(), '_meta_keywords', true );
-			}
-			$key = "single_{$post_type}";
-		} elseif ( is_front_page() ) {
-			$key = 'home';
-		} elseif ( is_author() ) {
-			$key = 'archive_author';
-		} elseif ( is_category() || is_tag() || is_tax() ) {
-			if ( WP_SEO_Settings()->has_term_fields( $taxonomy = get_queried_object()->taxonomy ) && $option = get_option( $this->get_term_option_name( get_queried_object() ) ) ) {
-				$meta_description = $option['description'];
-				$meta_keywords = $option['keywords'];
-			}
-			$key = "archive_{$taxonomy}";
-		} elseif ( is_post_type_archive() ) {
-			$key = 'archive_' . get_queried_object()->name;
-		} elseif ( is_date() ) {
-			$key = 'archive_date';
-		} else {
-			$key = false;
-		}
-
-		if ( $key ) {
-			if ( empty( $meta_description ) ) {
-				/**
-				 * Filter the format string of the meta description for this page.
-				 *
-				 * @param  string 		The format string retrieved from the settings.
-				 * @param  string $key	The key of the setting retrieved.
-				 */
-				$description_string = apply_filters( 'wp_seo_meta_description_format', WP_SEO_Settings()->get_option( "{$key}_description" ), $key );
-				$meta_description = $this->format( $description_string );
-			}
-
-			if ( $meta_description && ! is_wp_error( $meta_description ) ) {
-				$this->meta_field( 'description', $meta_description );
-			}
-
-			if ( empty( $meta_keywords ) ) {
-				/**
-				 * Filter the format string of the meta keywords for this page.
-				 *
-				 * @param  string 		The format string retrieved from the settings.
-				 * @param  string $key	The key of the setting retrieved.
-				 */
-				$keywords_string = apply_filters( 'wp_seo_meta_keywords_format', WP_SEO_Settings()->get_option( "{$key}_keywords" ), $key );
-				$meta_keywords = $this->format( $keywords_string );
-			}
-
-			if ( $meta_keywords && ! is_wp_error( $meta_keywords ) ) {
-				$this->meta_field( 'keywords', $meta_keywords );
+		/**
+		 * Add the SEO fields to post types that support them.
+		 *
+		 * @param string $post_type The current post type.
+		 */
+		public function add_meta_boxes( $post_type ) {
+			if ( WP_SEO_Settings()->has_post_fields( $post_type ) ) {
+				add_meta_box(
+					'wp_seo',
+					wp_seo_get_box_title(),
+					array( $this, 'post_meta_fields' ),
+					$post_type,
+					/**
+					 * Filter the screen context where the fields should display.
+					 *
+					 * @param  string @see add_meta_box().
+					 */
+					apply_filters( 'wp_seo_meta_box_context', 'normal' ),
+					/**
+					 * Filter the display priority of the fields within the context.
+					 *
+					 * @param  string @see add_meta_box().
+					 */
+					apply_filters( 'wp_seo_meta_box_priority', 'high' )
+				);
 			}
 		}
 
 		/**
-		 * Filter the artibrary meta tags that display on this page.
+		 * Display the SEO fields for a post.
 		 *
-		 * @param  array {
-		 *     Meta tag data.
-		 *
-		 *     @type  string $name    The field "name" attribute.
-		 *     @type  string $content The field "content" attribute.
-		 * }
+		 * @param  WP_Post $post The post being edited.
 		 */
-		$arbitrary_tags = apply_filters( 'wp_seo_arbitrary_tags', WP_SEO_Settings()->get_option( 'arbitrary_tags' ) );
-		if ( is_array( $arbitrary_tags ) ) {
-			foreach ( $arbitrary_tags as $tag ) {
-				$this->meta_field( $tag['name'], $this->format( $tag['content'] ) );
+		public function post_meta_fields( $post ) {
+			wp_nonce_field( plugin_basename( __FILE__ ), 'wp-seo-nonce' );
+
+			/**
+			 * Fires during the WP SEO post meta box display callback.
+			 *
+			 * @param WP_Post $post The post passed to the meta box display callback.
+			 */
+			do_action( 'wp_seo_post_meta_fields', $post );
+		}
+
+		/**
+		 * Save the SEO values as post meta.
+		 *
+		 * @param  int $post_id The post ID being edited.
+		 */
+		public function save_post_fields( $post_id ) {
+			if ( ! isset( $_POST['post_type'] ) ) {
+				return;
 			}
+
+			if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+				return;
+			}
+
+			if ( ! WP_SEO_Settings()->has_post_fields( $_POST['post_type'] ) ) {
+				return;
+			}
+
+			$post_type = get_post_type_object( $_POST['post_type'] );
+			if ( empty( $post_type->cap->edit_post ) || ! current_user_can( $post_type->cap->edit_post, $post_id ) ) {
+				return;
+			}
+
+			if ( ! isset( $_POST['wp-seo-nonce'] ) ) {
+				return;
+			}
+
+			if ( ! wp_verify_nonce( $_POST['wp-seo-nonce'], plugin_basename( __FILE__ ) ) ) {
+				return;
+			}
+
+			if ( ! isset( $_POST['post_ID'] ) ) {
+				return;
+			}
+
+			$post_id = absint( $_POST['post_ID'] );
+
+			if ( ! isset( $_POST['seo_meta'] ) ) {
+				$_POST['seo_meta'] = array();
+			}
+
+			foreach ( array( 'title', 'description', 'keywords' ) as $field ) {
+				$data = isset( $_POST['seo_meta'][ $field ] ) ? sanitize_text_field( $_POST['seo_meta'][ $field ] ) : '';
+				update_post_meta( $post_id, '_meta_' . $field, $data );
+			}
+		}
+
+		/**
+		 * Add the meta box to taxonomies with per-term fields enabled.
+		 */
+		public function add_term_boxes() {
+			foreach ( WP_SEO_Settings()->get_enabled_taxonomies() as $slug ) {
+				add_action( $slug . '_add_form_fields', array( $this, 'add_term_meta_fields' ) );
+				add_action( $slug . '_edit_form', array( $this, 'edit_term_meta_fields' ), 10, 2 );
+			}
+			add_action( 'created_term', array( $this, 'save_term_fields' ), 10, 3 );
+			add_action( 'edited_term', array( $this, 'save_term_fields' ), 10, 3 );
+		}
+
+		/**
+		 * Helper to construct an option name for per-term SEO fields.
+		 *
+		 * @param  object $term The term object
+		 * @return string The option name
+		 */
+		public function get_term_option_name( $term ) {
+			return "wp-seo-term-{$term->term_taxonomy_id}";
+		}
+
+		/**
+		 * Display the SEO fields for adding a term.
+		 *
+		 * @param string $taxonomy The taxonomy slug.
+		 */
+		public function add_term_meta_fields( $taxonomy ) {
+			wp_nonce_field( plugin_basename( __FILE__ ), 'wp-seo-nonce' );
+
+			/**
+			 * Fires during the WP SEO add-term fields display callback.
+			 *
+			 * @param string $taxonomy The taxonomy slug.
+			 */
+			do_action( 'wp_seo_add_term_meta_fields', $taxonomy );
+		}
+
+		/**
+		 * Display the SEO fields for editing a term.
+		 *
+		 * @param  object $tag The term object
+		 * @param  string $taxonomy The taxonomy slug
+		 */
+		public function edit_term_meta_fields( $tag, $taxonomy ) {
+			wp_nonce_field( plugin_basename( __FILE__ ), 'wp-seo-nonce' );
+
+			/**
+			 * Fires during the WP SEO edit-term fields display callback.
+			 *
+			 * @param WP_Term $tag The term object.
+			 * @param string $taxonomy The taxonomy slug.
+			 */
+			do_action( 'wp_seo_edit_term_meta_fields', $tag, $taxonomy );
+		}
+
+		/**
+		 * Save the SEO term values as an option.
+		 *
+		 * @see wp_unslash(), which the Settings API and update_post_meta()
+		 *     otherwise handle.
+		 *
+		 * @param  int $term_id Term ID.
+		 * @param  int $tt_id Term taxonomy ID.
+		 * @param  string $taxonomy Taxonomy slug.
+		 */
+		public function save_term_fields( $term_id, $tt_id, $taxonomy ) {
+			if ( ! isset( $_POST['taxonomy'] ) ) {
+				return;
+			}
+
+			if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+				return;
+			}
+
+			if ( ! WP_SEO_Settings()->has_term_fields( $taxonomy ) ) {
+				return;
+			}
+
+			$object = get_taxonomy( $taxonomy );
+			if ( empty( $object->cap->edit_terms ) || ! current_user_can( $object->cap->edit_terms ) ) {
+				return;
+			}
+
+			if ( ! isset( $_POST['wp-seo-nonce'] ) ) {
+				return;
+			}
+
+			if ( ! wp_verify_nonce( $_POST['wp-seo-nonce'], plugin_basename( __FILE__ ) ) ) {
+				return;
+			}
+
+			if ( ! isset( $_POST['seo_meta'] ) ) {
+				$_POST['seo_meta'] = array();
+			}
+
+			foreach ( array( 'title', 'description', 'keywords' ) as $field ) {
+				$data[ $field ] = isset( $_POST['seo_meta'][ $field ] ) ? sanitize_text_field( wp_unslash( $_POST['seo_meta'][ $field ] ) ) : '';
+			}
+
+			$name = $this->get_term_option_name( get_term( $term_id, $taxonomy ) );
+			if ( false === get_option( $name ) ) {
+				// Don't create an option unless at least one field exists.
+				$filtered_data = array_filter( $data );
+				if ( ! empty( $filtered_data ) ) {
+					add_option( $name, $data, null, false );
+				}
+			} else {
+				update_option( $name, $data );
+			}
+		}
+
+		/**
+		 * Replace formatting tags in a string with their value for the current page.
+		 *
+		 * @param  string $string  The string with formatting tags.
+		 * @return string|WP_Error The formatted string, or WP_Error on error.
+		 */
+		public function format( $string ) {
+			if ( ! is_string( $string ) ) {
+				return new WP_Error( 'format_error', __( "Please don't try to format() a non-string.", 'wp-seo' ) );
+			}
+
+			$raw_string = $string;
+
+			$matches = wp_seo_match_all_formatting_tags( $string );
+			if ( empty( $matches ) ) {
+				return $string;
+			}
+
+			$replacements = array();
+			$unique_matches = array_unique( $matches );
+
+			foreach( $this->formatting_tags as $id => $tag ) {
+				if ( ! empty( $tag->tag ) && in_array( $tag->tag, $unique_matches ) ) {
+					/**
+					 * Filter the value of a formatting tag for the current page.
+					 *
+					 * The dynamic portion of the hook name, $id, refers to the key
+					 * used to register the tag in WP_SEO::set_properties(). For
+					 * example, the hook for the default "#site_name#" formatting
+					 * tag is 'wp_seo_format_site_name'.
+					 *
+					 * @see wp_seo_default_formatting_tags() for the defaults' keys.
+					 *
+					 * @param  string The value returned by the formatting tag.
+					 */
+					$replacements[ $tag->tag ] = apply_filters( "wp_seo_format_{$id}", $tag->get_value() );
+				}
+			}
+
+			if ( ! empty( $replacements ) ) {
+				$string = str_replace( array_keys( $replacements ), array_values( $replacements ), $string );
+			}
+
+			/**
+			 * Filter the formatted string.
+			 *
+			 * @param  string $string 		The formatted string.
+			 * @param  string $raw_string 	The string as submitted.
+			 */
+			return apply_filters( 'wp_seo_after_format_string', $string, $raw_string );
+		}
+
+		/**
+		 * Filter the page title with the custom title or formatted title.
+		 *
+		 * @param  string $title The page title from wp_title().
+		 * @param  string $sep   The title separator.
+		 * @return string        The custom title of the current entry, if one
+		 *                       exists, or the formatted title from the settings
+		 *                       for the current post type. The original title if no
+		 *                       custom or formatted title exists.
+		 */
+		public function wp_title( $title, $sep ) {
+			if ( is_singular() ) {
+				if ( WP_SEO_Settings()->has_post_fields( $post_type = get_post_type() ) && $meta_title = get_post_meta( get_the_ID(), '_meta_title', true ) ) {
+					return $meta_title;
+				} else {
+					$key = "single_{$post_type}_title";
+				}
+			} elseif ( is_front_page() ) {
+				$key = 'home_title';
+			} elseif ( is_author() ) {
+				$key = 'archive_author_title';
+			} elseif ( is_category() || is_tag() || is_tax() ) {
+				if ( ( WP_SEO_Settings()->has_term_fields( $taxonomy = get_queried_object()->taxonomy ) ) && ( $option = get_option( $this->get_term_option_name( get_queried_object() ) ) ) && ( ! empty( $option['title'] ) ) ) {
+					return $option['title'];
+				} else {
+					$key = "archive_{$taxonomy}_title";
+				}
+			} elseif ( is_post_type_archive() ) {
+				$key = 'archive_' . get_queried_object()->name . '_title';
+			} elseif ( is_date() ) {
+				$key = 'archive_date_title';
+			} elseif ( is_search() ) {
+				$key = 'search_title';
+			} elseif ( is_404() ) {
+				$key = '404_title';
+			} else {
+				$key = false;
+			}
+
+			if ( $key ) {
+				/**
+				 * Filter the format string of the title tag for the current page.
+				 *
+				 * @param  string		The format string retrieved from the settings.
+				 * @param  string $key 	The key of the setting retrieved.
+				 */
+				$title_string = apply_filters( 'wp_seo_title_tag_format', WP_SEO_Settings()->get_option( $key ), $key );
+				$title_tag = $this->format( $title_string );
+				if ( $title_tag && ! is_wp_error( $title_tag ) ) {
+					$title = $title_tag;
+				}
+			}
+
+			return $title;
+		}
+
+		/**
+		 * Filter the document title before it is generated.
+		 *
+		 * @param string $title The document title. Default empty string.
+		 * @return string The custom title, if any, or the received $title if none exists.
+		 */
+		public function pre_get_document_title( $title ) {
+			// We can lean on the logic already in WP_SEO::wp_title().
+			$custom = $this->wp_title( $title, '' );
+
+			if ( $custom ) {
+				$title = $custom;
+			}
+
+			return $title;
+		}
+
+		/**
+		 * Render a <meta /> field.
+		 *
+		 * @access private.
+		 *
+		 * @since 0.12.0 An HTML comment was added to the output.
+		 *
+		 * @param  string $name  The content of the "name" attribute.
+		 * @param  string $content The content of the "content" attribute.
+		 */
+		private function meta_field( $name, $content ) {
+			if ( ! is_string( $name ) || ! is_string( $content ) ) {
+				return;
+			}
+
+			echo "<meta name='" . esc_attr( $name ) . "' content='" . esc_attr( $content ) . "' /><!-- WP SEO -->\n";
+		}
+
+		/**
+		 * Determine the <meta> values for the current page.
+		 *
+		 * Unlike WP_SEO::wp_title(), custom per-entry and per-term values are not
+		 * returned immediately but rendered at the end of the method.
+		 *
+		 * @see WP_SEO::meta_field() for detail on how the values are rendered.
+		 */
+		public function wp_head() {
+			if ( is_singular() ) {
+				if ( WP_SEO_Settings()->has_post_fields( $post_type = get_post_type() ) ) {
+					$meta_description = get_post_meta( get_the_ID(), '_meta_description', true );
+					$meta_keywords = get_post_meta( get_the_ID(), '_meta_keywords', true );
+				}
+				$key = "single_{$post_type}";
+			} elseif ( is_front_page() ) {
+				$key = 'home';
+			} elseif ( is_author() ) {
+				$key = 'archive_author';
+			} elseif ( is_category() || is_tag() || is_tax() ) {
+				if ( WP_SEO_Settings()->has_term_fields( $taxonomy = get_queried_object()->taxonomy ) && $option = get_option( $this->get_term_option_name( get_queried_object() ) ) ) {
+					$meta_description = $option['description'];
+					$meta_keywords = $option['keywords'];
+				}
+				$key = "archive_{$taxonomy}";
+			} elseif ( is_post_type_archive() ) {
+				$key = 'archive_' . get_queried_object()->name;
+			} elseif ( is_date() ) {
+				$key = 'archive_date';
+			} else {
+				$key = false;
+			}
+
+			if ( $key ) {
+				if ( empty( $meta_description ) ) {
+					/**
+					 * Filter the format string of the meta description for this page.
+					 *
+					 * @param  string 		The format string retrieved from the settings.
+					 * @param  string $key	The key of the setting retrieved.
+					 */
+					$description_string = apply_filters( 'wp_seo_meta_description_format', WP_SEO_Settings()->get_option( "{$key}_description" ), $key );
+					$meta_description = $this->format( $description_string );
+				}
+
+				if ( $meta_description && ! is_wp_error( $meta_description ) ) {
+					$this->meta_field( 'description', $meta_description );
+				}
+
+				if ( empty( $meta_keywords ) ) {
+					/**
+					 * Filter the format string of the meta keywords for this page.
+					 *
+					 * @param  string 		The format string retrieved from the settings.
+					 * @param  string $key	The key of the setting retrieved.
+					 */
+					$keywords_string = apply_filters( 'wp_seo_meta_keywords_format', WP_SEO_Settings()->get_option( "{$key}_keywords" ), $key );
+					$meta_keywords = $this->format( $keywords_string );
+				}
+
+				if ( $meta_keywords && ! is_wp_error( $meta_keywords ) ) {
+					$this->meta_field( 'keywords', $meta_keywords );
+				}
+			}
+
+			/**
+			 * Filter the artibrary meta tags that display on this page.
+			 *
+			 * @param  array {
+			 *     Meta tag data.
+			 *
+			 *     @type  string $name    The field "name" attribute.
+			 *     @type  string $content The field "content" attribute.
+			 * }
+			 */
+			$arbitrary_tags = apply_filters( 'wp_seo_arbitrary_tags', WP_SEO_Settings()->get_option( 'arbitrary_tags' ) );
+			if ( is_array( $arbitrary_tags ) ) {
+				foreach ( $arbitrary_tags as $tag ) {
+					$this->meta_field( $tag['name'], $this->format( $tag['content'] ) );
+				}
+			}
+
 		}
 
 	}
 
-}
-
-function WP_SEO() {
-	return WP_SEO::instance();
-}
-add_action( 'after_setup_theme', 'WP_SEO' );
-
+	function WP_SEO() {
+		return WP_SEO::instance();
+	}
+	add_action( 'after_setup_theme', 'WP_SEO' );
 endif;

--- a/php/default-formatting-tags.php
+++ b/php/default-formatting-tags.php
@@ -2,45 +2,101 @@
 /**
  * Default formatting tags.
  *
- * @see  WP_SEO_Formatting_Tag for property and method details.
+ * @see WP_SEO_Formatting_Tag for property and method details.
+ *
+ * @package WP_SEO
  */
 
+/**
+ * Formatting tag for the site name.
+ */
 class WP_SEO_Format_Site_Name extends WP_SEO_Formatting_Tag {
 
+	/**
+	 * Tag name.
+	 *
+	 * @var string
+	 */
 	public $tag = '#site_name#';
 
+	/**
+	 * Get the tag description.
+	 *
+	 * @return string
+	 */
 	public function get_description() {
 		return __( "Replaced with this site's name.", 'wp-seo' );
 	}
 
+	/**
+	 * Get the tag value for the current page.
+	 *
+	 * @return string Site name.
+	 */
 	public function get_value() {
 		return get_bloginfo( 'name' );
 	}
 
 }
 
+/**
+ * Formatting tag for the site description.
+ */
 class WP_SEO_Format_Site_Description extends WP_SEO_Formatting_Tag {
 
+	/**
+	 * Tag name.
+	 *
+	 * @var string
+	 */
 	public $tag = '#site_description#';
 
+	/**
+	 * Get the tag description.
+	 *
+	 * @return string
+	 */
 	public function get_description() {
 		return __( "Replaced with this site's description.", 'wp-seo' );
 	}
 
+	/**
+	 * Get the tag value for the current page.
+	 *
+	 * @return string Site description.
+	 */
 	public function get_value() {
 		return get_bloginfo( 'description' );
 	}
 
 }
 
+/**
+ * Formatting tag for a post's title.
+ */
 class WP_SEO_Format_Title extends WP_SEO_Formatting_Tag {
 
+	/**
+	 * Tag name.
+	 *
+	 * @var string
+	 */
 	public $tag = '#title#';
 
+	/**
+	 * Get the tag description.
+	 *
+	 * @return string
+	 */
 	public function get_description() {
 		return __( 'Replaced with the title of the content being viewed.', 'wp-seo' );
 	}
 
+	/**
+	 * Get the tag value for the current page.
+	 *
+	 * @return mixed Post title, or false.
+	 */
 	public function get_value() {
 		if ( is_singular() && post_type_supports( get_post_type(), 'title' ) ) {
 			return single_post_title( '', false );
@@ -51,19 +107,36 @@ class WP_SEO_Format_Title extends WP_SEO_Formatting_Tag {
 
 }
 
+/**
+ * Formatting tag for a post's excerpt.
+ */
 class WP_SEO_Format_Excerpt extends WP_SEO_Formatting_Tag {
 
+	/**
+	 * Tag name.
+	 *
+	 * @var string
+	 */
 	public $tag = '#excerpt#';
 
+	/**
+	 * Get the tag description.
+	 *
+	 * @return string
+	 */
 	public function get_description() {
 		return __( "Replaced with the excerpt of the content being viewed. An excerpt is generated if one isn't written.", 'wp-seo' );
 	}
 
 	/**
-	 * Use the written excerpt if it exists.
+	 * Get the tag value for the current page.
 	 *
-	 * If there is no excerpt, then generate one similar to wp_trim_excerpt(),
+	 * Uses the written excerpt if it exists.
+	 *
+	 * If there is no excerpt, then generates one similar to wp_trim_excerpt(),
 	 * which fails to filter get_the_excerpt() itself at this point.
+	 *
+	 * @return mixed Post excerpt, or false.
 	 */
 	public function get_value() {
 		if ( is_singular() && post_type_supports( get_post_type(), 'excerpt' ) ) {
@@ -79,14 +152,32 @@ class WP_SEO_Format_Excerpt extends WP_SEO_Formatting_Tag {
 	}
 }
 
+/**
+ * Formatting tag for a post's publish date.
+ */
 class WP_SEO_Format_Date_Published extends WP_SEO_Formatting_Tag {
 
+	/**
+	 * Tag name.
+	 *
+	 * @var string
+	 */
 	public $tag = '#date_published#';
 
+	/**
+	 * Get the tag description.
+	 *
+	 * @return string
+	 */
 	public function get_description() {
 		return __( 'Replaced with the date that the content being viewed was published.', 'wp-seo' );
 	}
 
+	/**
+	 * Get the tag value for the current page.
+	 *
+	 * @return mixed Post-publish date, or false.
+	 */
 	public function get_value() {
 		if ( is_singular() ) {
 			return get_the_date();
@@ -97,14 +188,32 @@ class WP_SEO_Format_Date_Published extends WP_SEO_Formatting_Tag {
 
 }
 
+/**
+ * Formatting tag for a post's modified date.
+ */
 class WP_SEO_Format_Date_Modified extends WP_SEO_Formatting_Tag {
 
+	/**
+	 * Tag name.
+	 *
+	 * @var string
+	 */
 	public $tag = '#date_modified#';
 
+	/**
+	 * Get the tag description.
+	 *
+	 * @return string
+	 */
 	public function get_description() {
 		return __( 'Replaced with the date that the content being viewed was last modified.', 'wp-seo' );
 	}
 
+	/**
+	 * Get the tag value for the current page.
+	 *
+	 * @return mixed Post-modified date, or false.
+	 */
 	public function get_value() {
 		if ( is_singular() ) {
 			return get_the_modified_date();
@@ -115,22 +224,39 @@ class WP_SEO_Format_Date_Modified extends WP_SEO_Formatting_Tag {
 
 }
 
+/**
+ * Formatting tag for a post's author.
+ */
 class WP_SEO_Format_Author extends WP_SEO_Formatting_Tag {
 
+	/**
+	 * Tag name.
+	 *
+	 * @var string
+	 */
 	public $tag = '#author#';
 
+	/**
+	 * Get the tag description.
+	 *
+	 * @return string
+	 */
 	public function get_description() {
 		return __( 'Replaced with the author name of the content or author archive being viewed.', 'wp-seo' );
 	}
 
 	/**
-	 * On singular, use get_the_author() if it's available.
+	 * Get the tag value for the current page.
 	 *
-	 * If it isn't available yet, get the author field from the post ID, and
+	 * On singular, uses get_the_author() if it's available.
+	 *
+	 * If it isn't available yet, gets the author field from the post ID, and
 	 * apply the 'the_author' filter for Co-Authors Plus support.
 	 *
-	 * On author archives, get author data directly from the queried object, not
-	 * get_the_author(), to prevent Co-Authors Plus from filtering it.
+	 * On author archives, gets author data directly from the queried object,
+	 * not get_the_author(), to prevent Co-Authors Plus from filtering it.
+	 *
+	 * @return mixed Author name, or false.
 	 */
 	public function get_value() {
 		if ( is_singular() && post_type_supports( get_post_type(), 'author' ) ) {
@@ -148,14 +274,32 @@ class WP_SEO_Format_Author extends WP_SEO_Formatting_Tag {
 
 }
 
+/**
+ * Formatting tag for a post's categories.
+ */
 class WP_SEO_Format_Categories extends WP_SEO_Formatting_Tag {
 
+	/**
+	 * Tag name.
+	 *
+	 * @var string
+	 */
 	public $tag = '#categories#';
 
+	/**
+	 * Get the tag description.
+	 *
+	 * @return string
+	 */
 	public function get_description() {
 		return __( 'Replaced with the Categories, comma-separated, of the content being viewed.', 'wp-seo' );
 	}
 
+	/**
+	 * Get the tag value for the current page.
+	 *
+	 * @return mixed Category list, or false.
+	 */
 	public function get_value() {
 		if ( is_singular() && is_object_in_taxonomy( get_post_type(), 'category' ) && $categories = get_the_category() ) {
 			return implode( __( ', ', 'wp-seo' ), wp_list_pluck( $categories, 'name' ) );
@@ -166,14 +310,32 @@ class WP_SEO_Format_Categories extends WP_SEO_Formatting_Tag {
 
 }
 
+/**
+ * Formatting tag for a post's tags.
+ */
 class WP_SEO_Format_Tags extends WP_SEO_Formatting_Tag {
 
+	/**
+	 * (Formatting) tag name.
+	 *
+	 * @var string
+	 */
 	public $tag = '#tags#';
 
+	/**
+	 * Get the (formatting) tag description.
+	 *
+	 * @return string
+	 */
 	public function get_description() {
 		return __( 'Replaced with the Tags, comma-separated, of the content being viewed.', 'wp-seo' );
 	}
 
+	/**
+	 * Get the (formatting) tag value for the current page.
+	 *
+	 * @return mixed Tag list, or false.
+	 */
 	public function get_value() {
 		if ( is_singular() && is_object_in_taxonomy( get_post_type(), 'post_tag' ) && $tags = get_the_tags() ) {
 			return implode( __( ', ', 'wp-seo' ), wp_list_pluck( $tags, 'name' ) );
@@ -184,14 +346,32 @@ class WP_SEO_Format_Tags extends WP_SEO_Formatting_Tag {
 
 }
 
+/**
+ * Formatting tag for a term's name.
+ */
 class WP_SEO_Format_Term_Name extends WP_SEO_Formatting_Tag {
 
+	/**
+	 * Tag name.
+	 *
+	 * @var string
+	 */
 	public $tag = '#term_name#';
 
+	/**
+	 * Get the tag description.
+	 *
+	 * @return string
+	 */
 	public function get_description() {
 		return __( 'Replaced with the name of the term whose archive is being viewed.', 'wp-seo' );
 	}
 
+	/**
+	 * Get the tag value for the current page.
+	 *
+	 * @return mixed Term name, or false.
+	 */
 	public function get_value() {
 		if ( is_category() || is_tag() || is_tax() ) {
 			return get_queried_object()->name;
@@ -202,14 +382,32 @@ class WP_SEO_Format_Term_Name extends WP_SEO_Formatting_Tag {
 
 }
 
+/**
+ * Formatting tag for a term's description.
+ */
 class WP_SEO_Format_Term_Description extends WP_SEO_Formatting_Tag {
 
+	/**
+	 * Tag name.
+	 *
+	 * @var string
+	 */
 	public $tag = '#term_description#';
 
+	/**
+	 * Get the tag description.
+	 *
+	 * @return string
+	 */
 	public function get_description() {
 		return __( 'Replaced with the description of the term whose archive is being viewed.', 'wp-seo' );
 	}
 
+	/**
+	 * Get the tag value for the current page.
+	 *
+	 * @return mixed Term description, or false.
+	 */
 	public function get_value() {
 		if ( is_category() || is_tag() || is_tax() ) {
 			return get_queried_object()->description;
@@ -220,14 +418,32 @@ class WP_SEO_Format_Term_Description extends WP_SEO_Formatting_Tag {
 
 }
 
+/**
+ * Formatting tag for a post type's singular name.
+ */
 class WP_SEO_Format_Post_Type_Singular_Name extends WP_SEO_Formatting_Tag {
 
+	/**
+	 * Tag name.
+	 *
+	 * @var string
+	 */
 	public $tag = '#post_type_singular_name#';
 
+	/**
+	 * Get the tag description.
+	 *
+	 * @return string
+	 */
 	public function get_description() {
 		return __( 'Replaced with the singular form of the name of the post type being viewed.', 'wp-seo' );
 	}
 
+	/**
+	 * Get the tag value for the current page.
+	 *
+	 * @return mixed Post type singular name, or false.
+	 */
 	public function get_value() {
 		if ( is_singular() ) {
 			return get_post_type_object( get_post_type() )->labels->singular_name;
@@ -240,14 +456,32 @@ class WP_SEO_Format_Post_Type_Singular_Name extends WP_SEO_Formatting_Tag {
 
 }
 
+/**
+ * Formatting tag for a post type's plural name.
+ */
 class WP_SEO_Format_Post_Type_Plural_Name extends WP_SEO_Formatting_Tag {
 
+	/**
+	 * Tag name.
+	 *
+	 * @var string
+	 */
 	public $tag = '#post_type_plural_name#';
 
+	/**
+	 * Get the tag description.
+	 *
+	 * @return string
+	 */
 	public function get_description() {
 		return __( 'Replaced with the plural form of the name of the post type being viewed.', 'wp-seo' );
 	}
 
+	/**
+	 * Get the tag value for the current page.
+	 *
+	 * @return mixed Post type plural name, or false.
+	 */
 	public function get_value() {
 		if ( is_singular() ) {
 			return get_post_type_object( get_post_type() )->labels->name;
@@ -260,15 +494,34 @@ class WP_SEO_Format_Post_Type_Plural_Name extends WP_SEO_Formatting_Tag {
 
 }
 
+/**
+ * Formatting tag for the date of a date archive.
+ */
 class WP_SEO_Format_Archive_Date extends WP_SEO_Formatting_Tag {
 
+	/**
+	 * Tag name.
+	 *
+	 * @var string
+	 */
 	public $tag = '#archive_date#';
 
+	/**
+	 * Get the tag description.
+	 *
+	 * @return string
+	 */
 	public function get_description() {
 		return __( 'Replaced with the date of the archive being viewed.', 'wp-seo' );
 	}
 
-	// @see the "_s" theme for these date strings.
+	/**
+	 * Get the tag value for the current page.
+	 *
+	 * @see The "_s" theme for these date strings.
+	 *
+	 * @return mixed Date of the archive being viewed, or false.
+	 */
 	public function get_value() {
 		if ( is_day() ) {
 			return get_the_date();
@@ -283,14 +536,32 @@ class WP_SEO_Format_Archive_Date extends WP_SEO_Formatting_Tag {
 
 }
 
+/**
+ * Formatting tag for a user's search term.
+ */
 class WP_SEO_Format_Search_Term extends WP_SEO_Formatting_Tag {
 
+	/**
+	 * Tag name.
+	 *
+	 * @var string
+	 */
 	public $tag = '#search_term#';
 
+	/**
+	 * Get the tag description.
+	 *
+	 * @return string
+	 */
 	public function get_description() {
 		return __( "Replaced with the user's search term.", 'wp-seo' );
 	}
 
+	/**
+	 * Get the tag value for the current page.
+	 *
+	 * @return mixed Search term, or false.
+	 */
 	public function get_value() {
 		return ( $term = get_search_query() ) ? $term : false;
 	}


### PR DESCRIPTION
 `class-wp-seo.php` was indented by one tab; viewing this PR with `?w=1` makes that change invisible.

See #42.