### PR TITLE
Add social meta to WP_SEO

### DIFF
--- a/tests/test-admin-functions.php
+++ b/tests/test-admin-functions.php
@@ -31,15 +31,23 @@ class WP_SEO_Admin_Functions_Tests extends WP_SEO_Testcase {
 	 * }
 	 */
 	function data_post_id_to_functions() {
-		$meta_title       = rand_str( rand( 32, 64 ) );
-		$meta_description = rand_str( rand( 32, 64 ) );
-		$meta_keywords    = rand_str( rand( 32, 64 ) );
+		$meta_title             = rand_str( rand( 32, 64 ) );
+		$meta_description       = rand_str( rand( 32, 64 ) );
+		$meta_keywords          = rand_str( rand( 32, 64 ) );
+		$meta_og_title          = rand_str( rand( 32, 64 ) );
+		$meta_og_description    = rand_str( rand( 32, 64 ) );
+		$meta_og_type           = rand_str( rand( 32, 64 ) );
+		$meta_og_image          = $this->factory->attachment->create();
 
 		$post_id = $this->factory->post->create( array(
 			'meta_input' => array(
-				'_meta_title'       => $meta_title,
-				'_meta_description' => $meta_description,
-				'_meta_keywords'    => $meta_keywords,
+				'_meta_title'          => $meta_title,
+				'_meta_description'    => $meta_description,
+				'_meta_keywords'       => $meta_keywords,
+				'_meta_og_title'       => $meta_title,
+				'_meta_og_description' => $meta_description,
+				'_meta_og_type'        => $meta_og_type,
+				'_meta_og_image'       => $meta_og_image,
 			),
 		) );
 
@@ -74,6 +82,42 @@ class WP_SEO_Admin_Functions_Tests extends WP_SEO_Testcase {
 				$meta_keywords,
 				array( $post_id ),
 			),
+			array(
+				'wp_seo_post_id_to_the_meta_og_title_input',
+				'Should print the OG title value in post meta',
+				$meta_og_title,
+				array( $post_id ),
+			),
+			array(
+				'wp_seo_post_id_to_the_og_title_character_count',
+				'Should count the OG title value in post meta',
+				(string) strlen( $meta_og_title ),
+				array( $post_id ),
+			),
+			array(
+				'wp_seo_post_id_to_the_meta_og_description_input',
+				'Should print the OG description value in post meta',
+				$meta_og_description,
+				array( $post_id ),
+			),
+			array(
+				'wp_seo_post_id_to_the_og_description_character_count',
+				'Should count the OG description value in post meta',
+				(string) strlen( $meta_og_description ),
+				array( $post_id ),
+			),
+			array(
+				'wp_seo_post_id_to_the_meta_og_type_input',
+				'Should print the OG type value in post meta',
+				$meta_og_type,
+				array( $post_id ),
+			),
+			array(
+				'wp_seo_post_id_to_the_meta_og_image_input',
+				'Should print the OG image value in post meta',
+				wp_get_attachment_image_src( $meta_og_image ),
+				array( $post_id ),
+			),
 		);
 	}
 
@@ -85,14 +129,22 @@ class WP_SEO_Admin_Functions_Tests extends WP_SEO_Testcase {
 	 * }
 	 */
 	function data_term_data_to_functions() {
-		$title       = rand_str( rand( 32, 64 ) );
-		$description = rand_str( rand( 32, 64 ) );
-		$keywords    = rand_str( rand( 32, 64 ) );
+		$meta_title             = rand_str( rand( 32, 64 ) );
+		$meta_description       = rand_str( rand( 32, 64 ) );
+		$meta_keywords          = rand_str( rand( 32, 64 ) );
+		$meta_og_title          = rand_str( rand( 32, 64 ) );
+		$meta_og_description    = rand_str( rand( 32, 64 ) );
+		$meta_og_type           = rand_str( rand( 32, 64 ) );
+		$meta_og_image          = $this->factory->attachment->create();
 
 		$term = $this->create_and_get_term_with_option( array(
 			'title' => $title,
-			'description' => $description,
-			'keywords' => $keywords,
+			'description'    => $description,
+			'keywords'       => $keywords,
+			'og_title'       => $meta_title,
+			'og_description' => $meta_description,
+			'og_type'        => $meta_og_type,
+			'og_image'       => $meta_og_image,
 		) );
 
 		return array(
@@ -125,6 +177,42 @@ class WP_SEO_Admin_Functions_Tests extends WP_SEO_Testcase {
 				'Should print the keyword value in the term options',
 				$keywords,
 				array( $term->term_id, $term->taxonomy ),
+			),
+			array(
+				'wp_seo_term_data_to_the_meta_og_title_input',
+				'Should print the OG title value in post meta',
+				$meta_og_title,
+				array( $term_data ),
+			),
+			array(
+				'wp_seo_term_data_to_the_og_title_character_count',
+				'Should count the OG title value in post meta',
+				(string) strlen( $meta_og_title ),
+				array( $term_data ),
+			),
+			array(
+				'wp_seo_term_data_to_the_meta_og_description_input',
+				'Should print the OG description value in post meta',
+				$meta_og_description,
+				array( $term_data ),
+			),
+			array(
+				'wp_seo_term_data_to_the_og_description_character_count',
+				'Should count the OG description value in post meta',
+				(string) strlen( $meta_og_description ),
+				array( $term_data ),
+			),
+			array(
+				'wp_seo_term_data_to_the_meta_og_type_input',
+				'Should print the OG type value in post meta',
+				$meta_og_type,
+				array( $term_data ),
+			),
+			array(
+				'wp_seo_term_data_to_the_meta_og_image_input',
+				'Should print the OG image value in post meta',
+				wp_get_attachment_image_src( $meta_og_image ),
+				array( $term_data ),
 			),
 		);
 	}

--- a/tests/test-metaboxes.php
+++ b/tests/test-metaboxes.php
@@ -74,6 +74,30 @@ class WP_SEO_Metaboxes_Tests extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that markup for post fields has our expected fields and values.
+	 */
+	function test_post_meta_og_fields() {
+		$post_ID = $this->factory->post->create();
+		$post = get_post( $post_ID );
+		$attachment_ID = $this->factory->attachment->create();
+		$title = rand_str();
+		$description = rand_str();
+		$type = rand_str();
+
+		add_post_meta( $post_ID, '_meta_og_image', $attachment_ID );
+		add_post_meta( $post_ID, '_meta_og_title', $title );
+		add_post_meta( $post_ID, '_meta_og_description', $description );
+		add_post_meta( $post_ID, '_meta_og_type', $description );
+
+		$html = get_echo( array( WP_SEO(), 'post_meta_fields' ), array( $post ) );
+		$this->assertRegExp( '/<input[^>]+type="hidden"[^>]+name="wp-seo-nonce"/', $html );
+		$this->assertContains( 'name="seo_meta[og_image]" value="' . $attachment_ID . '"', $html );
+		$this->assertContains( 'name="seo_meta[og_type]" value="' . $attachment_ID . '"', $type );
+		$this->assertContains( 'name="seo_meta[og_title]" value="' . $attachment_ID . '"', $title );
+		$this->assertContains( 'name="seo_meta[og_description]" value="' . $attachment_ID . '"', $description );
+	}
+
+	/**
 	 * Test most ways saving post fields can fail and the one way they succeed.
 	 */
 	function test_save_post_fields() {

--- a/tests/test-metaboxes.php
+++ b/tests/test-metaboxes.php
@@ -87,14 +87,14 @@ class WP_SEO_Metaboxes_Tests extends WP_UnitTestCase {
 		add_post_meta( $post_ID, '_meta_og_image', $attachment_ID );
 		add_post_meta( $post_ID, '_meta_og_title', $title );
 		add_post_meta( $post_ID, '_meta_og_description', $description );
-		add_post_meta( $post_ID, '_meta_og_type', $description );
+		add_post_meta( $post_ID, '_meta_og_type', $type );
 
 		$html = get_echo( array( WP_SEO(), 'post_meta_fields' ), array( $post ) );
 		$this->assertRegExp( '/<input[^>]+type="hidden"[^>]+name="wp-seo-nonce"/', $html );
 		$this->assertContains( 'name="seo_meta[og_image]" value="' . $attachment_ID . '"', $html );
-		$this->assertContains( 'name="seo_meta[og_type]" value="' . $attachment_ID . '"', $type );
-		$this->assertContains( 'name="seo_meta[og_title]" value="' . $attachment_ID . '"', $title );
-		$this->assertContains( 'name="seo_meta[og_description]" value="' . $attachment_ID . '"', $description );
+		$this->assertContains( 'name="seo_meta[og_type]" value="' . $type . '"', $type );
+		$this->assertContains( 'name="seo_meta[og_title]" value="' . $title . '"', $title );
+		$this->assertContains( 'name="seo_meta[og_description]" value="' . $description . '"', $description );
 	}
 
 	/**
@@ -147,16 +147,28 @@ class WP_SEO_Metaboxes_Tests extends WP_UnitTestCase {
 		$this->assertEmpty( get_post_meta( $post_ID, '_meta_title', true ) );
 		$this->assertEmpty( get_post_meta( $post_ID, '_meta_description', true ) );
 		$this->assertEmpty( get_post_meta( $post_ID, '_meta_keywords', true ) );
+		$this->assertEmpty( get_post_meta( $post_ID, '_meta_og_title', true ) );
+		$this->assertEmpty( get_post_meta( $post_ID, '_meta_og_description', true ) );
+		$this->assertEmpty( get_post_meta( $post_ID, '_meta_og_type', true ) );
+		$this->assertEmpty( get_post_meta( $post_ID, '_meta_og_image', true ) );
 
 		$title = rand_str();
 		$description = rand_str();
 		$keywords = rand_str();
+		$og_title = rand_str();
+		$og_description = rand_str();
+		$og_type = rand_str();
+		$og_image = $this->factory->attachment->create();
 
 		// add_magic_quotes() to simulate wp_magic_quotes().
 		$_POST['seo_meta'] = add_magic_quotes( array(
-			'title' => $title,
-			'description' => $description . '<script>meta</script>',
-			'keywords' => $keywords,
+			'title'          => $title,
+			'description'    => $description . '<script>meta</script>',
+			'keywords'       => $keywords,
+			'og_title'       => $og_title,
+			'og_description' => $og_description,
+			'og_type'        => $og_type,
+			'og_image'       => $og_image,
 		) );
 
 		// Successful save.
@@ -164,22 +176,38 @@ class WP_SEO_Metaboxes_Tests extends WP_UnitTestCase {
 		$this->assertEquals( $title, get_post_meta( $post_ID, '_meta_title', true ) );
 		$this->assertEquals( $description, get_post_meta( $post_ID, '_meta_description', true ) );
 		$this->assertEquals( $keywords, get_post_meta( $post_ID, '_meta_keywords', true ) );
+		$this->assertEquals( $og_title, get_post_meta( $post_ID, '_meta_og_title', true ) );
+		$this->assertEquals( $og_description, get_post_meta( $post_ID, '_meta_og_description', true ) );
+		$this->assertEquals( $og_type, get_post_meta( $post_ID, '_meta_og_type', true ) );
+		$this->assertEquals( $og_image, get_post_meta( $post_ID, '_meta_og_image', true ) );
 
 		$title = "Is your name O'Reilly?";
 		$description = 'What is Folder\SubFolder\File.txt?';
 		$keywords = '';
+		$og_title = rand_str();
+		$og_description = 'What is Folder\SubFolder\File.txt?';
+		$og_type = rand_str();
+		$og_image = $this->factory->attachment->create();
 
 		// Successfully save data with slashes. add_magic_quotes() to simulate wp_magic_quotes().
 		$_POST['seo_meta'] = add_magic_quotes( array(
-			'title'       => $title,
-			'description' => $description,
-			'keywords'    => $keywords,
+			'title'          => $title,
+			'description'    => $description,
+			'keywords'       => $keywords,
+			'og_title'       => $og_title,
+			'og_description' => $og_description,
+			'og_type'        => $og_type,
+			'og_image'       => $og_image,
 		) );
 
 		WP_SEO()->save_post_fields( $post_ID );
 		$this->assertEquals( $title, get_post_meta( $post_ID, '_meta_title', true ) );
 		$this->assertEquals( $description, get_post_meta( $post_ID, '_meta_description', true ) );
 		$this->assertEquals( $keywords, get_post_meta( $post_ID, '_meta_keywords', true ) );
+		$this->assertEquals( $og_title, get_post_meta( $post_ID, '_meta_og_title', true ) );
+		$this->assertEquals( $og_description, get_post_meta( $post_ID, '_meta_og_description', true ) );
+		$this->assertEquals( $og_type, get_post_meta( $post_ID, '_meta_og_type', true ) );
+		$this->assertEquals( $og_image, get_post_meta( $post_ID, '_meta_og_image', true ) );
 	}
 
 	/**
@@ -203,6 +231,10 @@ class WP_SEO_Metaboxes_Tests extends WP_UnitTestCase {
 		$this->assertContains( 'name="seo_meta[title]"', $html );
 		$this->assertContains( 'name="seo_meta[description]"', $html );
 		$this->assertContains( 'name="seo_meta[keywords]"', $html );
+		$this->assertContains( 'name="seo_meta[og_title]"', $html );
+		$this->assertContains( 'name="seo_meta[og_description]"', $html );
+		$this->assertContains( 'name="seo_meta[og_type]"', $html );
+		$this->assertContains( 'name="seo_meta[og_image]"', $html );
 	}
 
 	/**
@@ -215,13 +247,21 @@ class WP_SEO_Metaboxes_Tests extends WP_UnitTestCase {
 		$title = rand_str();
 		$description = rand_str();
 		$keywords = rand_str();
+		$og_title = rand_str();
+		$og_description = rand_str();
+		$og_type = rand_str();
+		$og_image = $this->factory->attachment->create();
 
 		update_option(
 			WP_SEO()->get_term_option_name( $category ),
 			array(
-				'title' => $title,
-				'description' => $description,
-				'keywords' => $keywords,
+				'title'          => $title,
+				'description'    => $description,
+				'keywords'       => $keywords,
+				'og_title'       => $og_title,
+				'og_description' => $og_description,
+				'og_type'        => $og_type,
+				'og_image'       => $og_image,
 			)
 		);
 
@@ -233,6 +273,11 @@ class WP_SEO_Metaboxes_Tests extends WP_UnitTestCase {
 		$this->assertRegExp( "/<textarea.*?>{$description}<\/textarea>/", $html );
 		$this->assertContains( sprintf( '<noscript>%d (save changes to update)</noscript>', strlen( $description ) ), $html );
 		$this->assertRegExp( "/<textarea.*?>{$keywords}<\/textarea>/", $html );
+		$this->assertContains( 'name="seo_meta[og_title]" value="' . $og_title . '" size="96"', $html );
+		$this->assertContains( sprintf( '<noscript>%d (save changes to update)</noscript>', strlen( $og_title ) ), $html );
+		$this->assertRegExp( "/<textarea.*?>{$og_description}<\/textarea>/", $html );
+		$this->assertContains( sprintf( '<noscript>%d (save changes to update)</noscript>', strlen( $og_description ) ), $html );
+		// @TODO Add OG Type & OG Image test
 	}
 
 	function test_save_term_fields() {
@@ -274,30 +319,49 @@ class WP_SEO_Metaboxes_Tests extends WP_UnitTestCase {
 		$title = rand_str();
 		$description = rand_str();
 		$keywords = rand_str();
+		$og_title = rand_str();
+		$og_description = rand_str();
+		$og_type = rand_str();
+		$og_image = $this->factory->attachment->create();
 
 		$_POST['seo_meta'] = array(
-			'title' => $title,
-			'description' => $description . '<script>meta</script>',
-			'keywords' => $keywords,
+			'title'          => $title,
+			'description'    => $description . '<script>meta</script>',
+			'keywords'       => $keywords,
+			'og_title'       => $og_title,
+			'og_description' => $og_description,
+			'og_type'        => $og_type,
+			'og_image'       => $og_image,
 		);
 
 		// Successful add_option().
 		WP_SEO()->save_term_fields( $category_ID, $category->term_taxonomy_id, 'category' );
 		$this->assertSame(
 			array(
-				'title' => $title,
-				'description' => $description,
-				'keywords' => $keywords,
+				'title'          => $title,
+				'description'    => $description,
+				'keywords'       => $keywords,
+				'og_title'       => $og_title,
+				'og_description' => $og_description,
+				'og_type'        => $og_type,
+				'og_image'       => $og_image,
 			),
 			get_option( WP_SEO()->get_term_option_name( $category ) )
 		);
 
 		$updated_title = rand_str();
 		$updated_keywords = rand_str();
+		$update_og_title = rand_str();
+		$update_og_description = rand_str();
+		$update_og_type = rand_str();
+		$update_og_image = $this->factory->attachment->create();
 
 		$_POST['seo_meta'] = array(
-			'title' => $updated_title,
-			'keywords' => $updated_keywords,
+			'title'          => $updated_title,
+			'keywords'       => $updated_keywords,
+			'og_title'       => $updated_og_title,
+			'og_type'        => $updated_og_type,
+			'og_image'       => $updated_og_image,
 		);
 
 		// Successful update_option().
@@ -305,8 +369,12 @@ class WP_SEO_Metaboxes_Tests extends WP_UnitTestCase {
 		$this->assertSame(
 			array(
 				'title' => $updated_title,
-				'description' => '',
-				'keywords' => $updated_keywords,
+				'description'    => '',
+				'keywords'       => $updated_keywords,
+				'og_title'       => $og_title,
+				'og_description' => '',
+				'og_type'        => $og_type,
+				'og_image'       => $og_image,
 			),
 			get_option( WP_SEO()->get_term_option_name( $category ) )
 		);

--- a/tests/test-settings-page.php
+++ b/tests/test-settings-page.php
@@ -23,7 +23,7 @@ class WP_SEO_Settings_Page_Tests extends WP_UnitTestCase {
 		global $submenu;
 		$this->assertContains(
 			array(
-				'SEO',
+				'SEO & Social',
 				'manage_options',
 				'wp-seo',
 				'WP SEO Settings',


### PR DESCRIPTION
Initial TDD for adding social meta to WP_SEO.

Mockup of editor view:

![screen shot 2017-01-12 at 12 59 30 pm](https://cloud.githubusercontent.com/assets/1636964/21901773/1267edc4-d8c7-11e6-8cd5-736f9d77e2a5.png)
