### PR TITLE
Make plugin version a constant

### DIFF
--- a/php/admin-functions.php
+++ b/php/admin-functions.php
@@ -9,7 +9,7 @@
  * Enqueues scripts and styles for administration pages.
  */
 function wp_seo_admin_scripts() {
-	wp_enqueue_script( 'wp-seo-admin', WP_SEO_URL . 'js/wp-seo.js', array( 'jquery', 'underscore' ), '0.13.0', true );
+	wp_enqueue_script( 'wp-seo-admin', WP_SEO_URL . 'js/wp-seo.js', array( 'jquery', 'underscore' ), WP_SEO_VERSION, true );
 
 	wp_localize_script( 'wp-seo-admin', 'wp_seo_admin', array(
 		'ajaxurl' => admin_url( 'admin-ajax.php', 'relative' ),
@@ -24,7 +24,7 @@ function wp_seo_admin_scripts() {
 		'media_modal_title'         => __( 'Choose an image', 'wp-seo' ),
 	) );
 
-	wp_enqueue_style( 'wp-seo-admin', WP_SEO_URL . 'css/wp-seo.css', array(), '0.13.0' );
+	wp_enqueue_style( 'wp-seo-admin', WP_SEO_URL . 'css/wp-seo.css', array(), WP_SEO_VERSION );
 }
 
 /**

--- a/php/class-wp-seo.php
+++ b/php/class-wp-seo.php
@@ -18,13 +18,6 @@ if ( ! class_exists( 'WP_SEO' ) ) :
 		private static $instance = null;
 
 		/**
-		 * Current version of the plugin
-		 *
-		 * @var string
-		 */
-		public $plugin_version = '0.13.0';
-
-		/**
 		 * Associative array of WP_SEO_Formatting_Tag instances.
 		 *
 		 * @var array.

--- a/readme.txt
+++ b/readme.txt
@@ -138,6 +138,7 @@ When "safe mode" is disabled, WP SEO will include the unrecognized formatting ta
 * Added: Formatting tags can now be used in per-post and per-term meta values.
 * Added: Dropdown and image field types are now available for extension plugins.
 * Added: Filters to support extension plugins. See WP SEO Social for example.
+* Added: `WP_SEO_VERSION` constant.
 
 = 0.12.0 =
 * Added: `#thumbnail_url#` formatting tag, which represents the URL for the featured image of the content being viewed.

--- a/readme.txt
+++ b/readme.txt
@@ -139,6 +139,7 @@ When "safe mode" is disabled, WP SEO will include the unrecognized formatting ta
 * Added: Dropdown and image field types are now available for extension plugins.
 * Added: Filters to support extension plugins. See WP SEO Social for example.
 * Added: `WP_SEO_VERSION` constant.
+* Changed: Improve the UI when the post meta box is placed in the sidebar. Reported by johnbillion.
 
 = 0.12.0 =
 * Added: `#thumbnail_url#` formatting tag, which represents the URL for the featured image of the content being viewed.

--- a/wp-seo.php
+++ b/wp-seo.php
@@ -26,6 +26,14 @@
 
 define( 'WP_SEO_PATH', dirname( __FILE__ ) );
 define( 'WP_SEO_URL', trailingslashit( plugins_url( '', __FILE__ ) ) );
+
+/**
+ * Current plugin version.
+ *
+ * @since 0.13.0
+ *
+ * @var string $version
+ */
 define( 'WP_SEO_VERSION', '0.13.0' );
 
 // Behind-the-scenes functions.

--- a/wp-seo.php
+++ b/wp-seo.php
@@ -26,6 +26,7 @@
 
 define( 'WP_SEO_PATH', dirname( __FILE__ ) );
 define( 'WP_SEO_URL', trailingslashit( plugins_url( '', __FILE__ ) ) );
+define( 'WP_SEO_VERSION', '0.13.0' );
 
 // Behind-the-scenes functions.
 require_once WP_SEO_PATH . '/php/internal-functions.php';


### PR DESCRIPTION
I'm on board with making this available, but should it be changeable?

Also, uses the constant for enqueued asset versions so they follow the version of the plugin.