### PR TITLE
Migrate taxonomy settings to taxonomy specific namespace

### DIFF
--- a/php/class-wp-seo-fields.php
+++ b/php/class-wp-seo-fields.php
@@ -138,7 +138,7 @@ class WP_SEO_Fields {
 	 * @param  string $slug Optional slug for context use, defaults to WP_SEO slug.
 	 * @return void Prints text field.
 	 */
-	public function render_text_field( $args, $value, $slug = false  ) {
+	public function render_text_field( $args, $value, $slug = false ) {
 		if ( ! $slug ) {
 			$slug = WP_SEO_Settings()->get_slug();
 		}

--- a/php/class-wp-seo-fields.php
+++ b/php/class-wp-seo-fields.php
@@ -78,7 +78,7 @@ class WP_SEO_Fields {
 			$args['type'] = 'text';
 		}
 		if (
-			! WP_SEO_Settings()->taxonomy_migration &&
+			! WP_SEO_Settings()->has_taxonomy_migration_run() &&
 			substr( $args['field'], 0, 9 ) === 'taxonomy_' &&
 			array_filter(
 				array_map(

--- a/php/class-wp-seo-fields.php
+++ b/php/class-wp-seo-fields.php
@@ -77,9 +77,26 @@ class WP_SEO_Fields {
 		if ( empty( $args['type'] ) ) {
 			$args['type'] = 'text';
 		}
-
-		$value = ! empty( WP_SEO_Settings()->options[ $args['field'] ] ) ? WP_SEO_Settings()->options[ $args['field'] ] : '';
-
+		if (
+			! WP_SEO_Settings()->taxonomy_migration &&
+			substr( $args['field'], 0, 9 ) === 'taxonomy_' &&
+			array_filter(
+				array_map(
+					function( $taxonomy ) {
+						return $taxonomy->name;
+					},
+					WP_SEO_Settings()->taxonomies
+				),
+				function( $value ) use ( &$args ) {
+					return ( strpos( $args['field'], $value ) !== false);
+				}
+			)
+		) {
+			$legacy_field = str_replace( 'taxonomy_', 'archive_', $args['field'] );
+			$value = ! empty( WP_SEO_Settings()->options[ $legacy_field ] ) ? WP_SEO_Settings()->options[ $legacy_field ] : '';
+		} else {
+			$value = ! empty( WP_SEO_Settings()->options[ $args['field'] ] ) ? WP_SEO_Settings()->options[ $args['field'] ] : '';
+		}
 		switch ( $args['type'] ) {
 			case 'textarea' :
 				$this->render_textarea( $args, $value );

--- a/php/class-wp-seo-fields.php
+++ b/php/class-wp-seo-fields.php
@@ -87,7 +87,7 @@ class WP_SEO_Fields {
 					},
 					WP_SEO_Settings()->taxonomies
 				),
-				function( $value ) use ( &$args ) {
+				function( $value ) use ( $args ) {
 					return ( strpos( $args['field'], $value ) !== false);
 				}
 			)

--- a/php/class-wp-seo-format-site-name.php
+++ b/php/class-wp-seo-format-site-name.php
@@ -133,7 +133,8 @@ class WP_SEO_Format_Excerpt extends WP_SEO_Formatting_Tag {
 	 */
 	public function get_value() {
 		if ( is_singular() && post_type_supports( get_post_type(), 'excerpt' ) ) {
-			if ( $excerpt = get_the_excerpt() ) {
+			$excerpt = get_the_excerpt();
+			if ( $excerpt ) {
 				return $excerpt;
 			} else {
 				$post = get_post();
@@ -248,9 +249,11 @@ class WP_SEO_Format_Author extends WP_SEO_Formatting_Tag {
 	 */
 	public function get_value() {
 		if ( is_singular() && post_type_supports( get_post_type(), 'author' ) ) {
-			if ( $author = get_the_author() ) {
+			$author = get_the_author();
+			$post_author = get_post_field( 'post_author', get_the_ID() );
+			if ( $author ) {
 				return $author;
-			} elseif ( $post_author = get_post_field( 'post_author', get_the_ID() ) ) {
+			} elseif ( $post_author ) {
 				return apply_filters( 'the_author', get_the_author_meta( 'display_name', $post_author ) );
 			}
 		} elseif ( is_author() ) {
@@ -287,7 +290,8 @@ class WP_SEO_Format_Categories extends WP_SEO_Formatting_Tag {
 	 * @return mixed Category list, or false.
 	 */
 	public function get_value() {
-		if ( is_singular() && is_object_in_taxonomy( get_post_type(), 'category' ) && $categories = get_the_category() ) {
+		$categories = get_the_category();
+		if ( is_singular() && is_object_in_taxonomy( get_post_type(), 'category' ) && $categories ) {
 			return implode( __( ', ', 'wp-seo' ), wp_list_pluck( $categories, 'name' ) );
 		}
 
@@ -321,7 +325,8 @@ class WP_SEO_Format_Tags extends WP_SEO_Formatting_Tag {
 	 * @return mixed Tag list, or false.
 	 */
 	public function get_value() {
-		if ( is_singular() && is_object_in_taxonomy( get_post_type(), 'post_tag' ) && $tags = get_the_tags() ) {
+		$tags = get_the_tags();
+		if ( is_singular() && is_object_in_taxonomy( get_post_type(), 'post_tag' ) && $tags ) {
 			return implode( __( ', ', 'wp-seo' ), wp_list_pluck( $tags, 'name' ) );
 		}
 
@@ -535,7 +540,8 @@ class WP_SEO_Format_Search_Term extends WP_SEO_Formatting_Tag {
 	 * @return mixed Search term, or false.
 	 */
 	public function get_value() {
-		return ( $term = get_search_query() ) ? $term : false;
+		$term = get_search_query();
+		return ( $term ) ? $term : false;
 	}
 }
 

--- a/php/class-wp-seo-settings.php
+++ b/php/class-wp-seo-settings.php
@@ -1048,7 +1048,6 @@ class WP_SEO_Settings {
 			}
 		}
 
-
 		/*
 		 * If the migration has not run and should not run,
 		 * update the internal option to make it explicit.

--- a/php/class-wp-seo-settings.php
+++ b/php/class-wp-seo-settings.php
@@ -187,7 +187,7 @@ class WP_SEO_Settings {
 	 * @param array $old_value Associative array of old values.
 	 * @return array Associative array of filtered values.
 	 */
-	public function process_migration( $new_value, $old_value ) {
+	public function process_migration( $new_value, $old_value = array() ) {
 		if ( ! $this->taxonomy_migration ) {
 			foreach ( $this->taxonomies as $taxonomy ) {
 				unset( $new_value[ "archive_{$taxonomy->name}_title" ] );

--- a/php/class-wp-seo-settings.php
+++ b/php/class-wp-seo-settings.php
@@ -137,21 +137,63 @@ class WP_SEO_Settings {
 		 *
 		 * @param array Associative array of post type keys and objects.
 		 */
-		$this->single_post_types = apply_filters( 'wp_seo_single_post_types', wp_list_filter( get_post_types( array( 'public' => true ), 'objects' ), array( 'label' => false ), 'NOT' ) );
+		$this->single_post_types = apply_filters(
+			'wp_seo_single_post_types',
+			wp_list_filter(
+				get_post_types(
+					array(
+						'public' => true,
+					),
+					'objects'
+				),
+				array(
+					'label' => false,
+				),
+				'NOT'
+			)
+		);
 
 		/**
 		 * Filter the post types that support SEO fields on their archive pages.
 		 *
 		 * @param array Associative array of post type keys and objects.
 		 */
-		$this->archived_post_types = apply_filters( 'wp_seo_archived_post_types', wp_list_filter( get_post_types( array( 'has_archive' => true ), 'objects' ), array( 'label' => false ), 'NOT' ) );
+		$this->archived_post_types = apply_filters(
+			'wp_seo_archived_post_types',
+			wp_list_filter(
+				get_post_types(
+					array(
+						'has_archive' => true,
+					),
+					'objects'
+				),
+				array(
+					'label' => false,
+				),
+				'NOT'
+			)
+		);
 
 		/**
 		 * Filter the taxonomies that support SEO fields on term archive pages.
 		 *
 		 * @param  array Associative array of taxonomy keys and objects.
 		 */
-		$this->taxonomies = apply_filters( 'wp_seo_taxonomies', wp_list_filter( get_taxonomies( array( 'public' => true ), 'objects' ), array( 'label' => false ), 'NOT' ) );
+		$this->taxonomies = apply_filters(
+			'wp_seo_taxonomies',
+			wp_list_filter(
+				get_taxonomies(
+					array(
+						'public' => true,
+					),
+					'objects'
+				),
+				array(
+					'label' => false,
+				),
+				'NOT'
+			)
+		);
 
 		/**
 		 * Filter the options to save by default.
@@ -331,59 +373,367 @@ class WP_SEO_Settings {
 		register_setting( $this::SLUG, $this::SLUG, array( $this, 'sanitize_options' ) );
 
 		add_settings_section( 'home', __( 'Home Page', 'wp-seo' ), '__return_false', $this::SLUG );
-		add_settings_field( 'home_title', __( 'Title Tag Format', 'wp-seo' ), array( WP_SEO_Fields(), 'field' ), $this::SLUG, 'home', array( 'field' => 'home_title' ) );
-		add_settings_field( 'home_description', __( 'Meta Description Format', 'wp-seo' ), array( WP_SEO_Fields(), 'field' ), $this::SLUG, 'home', array( 'type' => 'textarea', 'field' => 'home_description' ) );
-		add_settings_field( 'home_keywords', __( 'Meta Keywords Format', 'wp-seo' ), array( WP_SEO_Fields(), 'field' ), $this::SLUG, 'home', array( 'field' => 'home_keywords' ) );
+		add_settings_field(
+			'home_title',
+			__( 'Title Tag Format', 'wp-seo' ),
+			array(
+				WP_SEO_Fields(),
+				'field',
+			),
+			$this::SLUG, 'home',
+			array(
+				'field' => 'home_title',
+			)
+		);
+		add_settings_field(
+			'home_description',
+			__( 'Meta Description Format', 'wp-seo' ),
+			array(
+				WP_SEO_Fields(),
+				'field',
+			),
+			$this::SLUG, 'home',
+			array(
+				'type' => 'textarea',
+				'field' => 'home_description',
+			)
+		);
+		add_settings_field(
+			'home_keywords',
+			__( 'Meta Keywords Format', 'wp-seo' ),
+			array(
+				WP_SEO_Fields(),
+				'field',
+			),
+			$this::SLUG,
+			'home',
+			array(
+				'field' => 'home_keywords',
+			)
+		);
 
 		add_settings_section( 'post_types', __( 'Post Types', 'wp-seo' ), '__return_false', $this::SLUG );
-		add_settings_field( 'post_types', __( 'Add SEO fields to individual:', 'wp-seo' ), array( WP_SEO_Fields(), 'field' ), $this::SLUG, 'post_types', array( 'field' => 'post_types', 'type' => 'checkboxes', 'boxes' => call_user_func_array( 'wp_list_pluck', array( $this->single_post_types, 'label' ) ) ) );
+		add_settings_field(
+			'post_types',
+			__( 'Add SEO fields to individual:', 'wp-seo' ),
+			array(
+				WP_SEO_Fields(),
+				'field',
+			),
+			$this::SLUG,
+			'post_types',
+			array(
+				'field' => 'post_types',
+				'type' => 'checkboxes',
+				'boxes' => call_user_func_array(
+					'wp_list_pluck',
+					array(
+						$this->single_post_types,
+						'label',
+					)
+				),
+			)
+		);
 
 		foreach ( $this->single_post_types as $post_type ) {
 			/* translators: %s: post type singular name */
 			add_settings_section( 'single_' . $post_type->name, sprintf( __( 'Single %s Defaults', 'wp-seo' ), $post_type->labels->singular_name ), array( $this, 'example_permalink' ), $this::SLUG );
-			add_settings_field( "single_{$post_type->name}_title", __( 'Title Tag Format', 'wp-seo' ), array( WP_SEO_Fields(), 'field' ), $this::SLUG, 'single_' . $post_type->name, array( 'field' => "single_{$post_type->name}_title" ) );
-			add_settings_field( "single_{$post_type->name}_description", __( 'Meta Description Format', 'wp-seo' ), array( WP_SEO_Fields(), 'field' ), $this::SLUG, 'single_' . $post_type->name, array( 'type' => 'textarea', 'field' => "single_{$post_type->name}_description" ) );
-			add_settings_field( "single_{$post_type->name}_keywords", __( 'Meta Keywords Format', 'wp-seo' ), array( WP_SEO_Fields(), 'field' ), $this::SLUG, 'single_' . $post_type->name, array( 'field' => "single_{$post_type->name}_keywords" ) );
+			add_settings_field(
+				"single_{$post_type->name}_title",
+				__( 'Title Tag Format', 'wp-seo' ),
+				array(
+					WP_SEO_Fields(),
+					'field',
+				),
+				$this::SLUG,
+				'single_' . $post_type->name,
+				array(
+					'field' => "single_{$post_type->name}_title",
+				)
+			);
+			add_settings_field(
+				"single_{$post_type->name}_description",
+				__( 'Meta Description Format', 'wp-seo' ),
+				array(
+					WP_SEO_Fields(),
+					'field',
+				),
+				$this::SLUG,
+				'single_' . $post_type->name,
+				array(
+					'type' => 'textarea',
+					'field' => "single_{$post_type->name}_description",
+				)
+			);
+			add_settings_field(
+				"single_{$post_type->name}_keywords",
+				__( 'Meta Keywords Format', 'wp-seo' ),
+				array(
+					WP_SEO_Fields(),
+					'field',
+				),
+				$this::SLUG,
+				'single_' . $post_type->name,
+				array(
+					'field' => "single_{$post_type->name}_keywords",
+				)
+			);
 		}
 
 		foreach ( $this->archived_post_types as $post_type ) {
 			/* translators: %s: post type singular name */
 			add_settings_section( 'archive_' . $post_type->name, sprintf( __( '%s Archives', 'wp-seo' ), $post_type->labels->singular_name ), array( $this, 'example_post_type_archive' ), $this::SLUG );
-			add_settings_field( "archive_{$post_type->name}_title", __( 'Title Tag Format', 'wp-seo' ), array( WP_SEO_Fields(), 'field' ), $this::SLUG, 'archive_' . $post_type->name, array( 'field' => "archive_{$post_type->name}_title" ) );
-			add_settings_field( "archive_{$post_type->name}_description", __( 'Meta Description Format', 'wp-seo' ), array( WP_SEO_Fields(), 'field' ), $this::SLUG, 'archive_' . $post_type->name, array( 'type' => 'textarea', 'field' => "archive_{$post_type->name}_description" ) );
-			add_settings_field( "archive_{$post_type->name}_keywords", __( 'Meta Keywords Format', 'wp-seo' ), array( WP_SEO_Fields(), 'field' ), $this::SLUG, 'archive_' . $post_type->name, array( 'field' => "archive_{$post_type->name}_keywords" ) );
+			add_settings_field(
+				"archive_{$post_type->name}_title",
+				__( 'Title Tag Format', 'wp-seo' ),
+				array(
+					WP_SEO_Fields(),
+					'field',
+				),
+				$this::SLUG,
+				'archive_' . $post_type->name,
+				array(
+					'field' => "archive_{$post_type->name}_title",
+				)
+			);
+			add_settings_field(
+				"archive_{$post_type->name}_description",
+				__( 'Meta Description Format', 'wp-seo' ),
+				array(
+					WP_SEO_Fields(),
+					'field',
+				),
+				$this::SLUG,
+				'archive_' . $post_type->name,
+				array(
+					'type' => 'textarea',
+					'field' => "archive_{$post_type->name}_description",
+				)
+			);
+			add_settings_field(
+				"archive_{$post_type->name}_keywords",
+				__( 'Meta Keywords Format', 'wp-seo' ),
+				array(
+					WP_SEO_Fields(),
+					'field',
+				),
+				$this::SLUG,
+				'archive_' . $post_type->name,
+				array(
+					'field' => "archive_{$post_type->name}_keywords",
+				)
+			);
 		}
 
 		// Post Formats have no UI, so they cannot have per-term fields.
 		add_settings_section( 'taxonomies', __( 'Taxonomies', 'wp-seo' ), '__return_false', $this::SLUG );
-		add_settings_field( 'taxonomies', __( 'Add SEO fields to individual:', 'wp-seo' ), array( WP_SEO_Fields(), 'field' ), $this::SLUG, 'taxonomies', array( 'field' => 'taxonomies', 'type' => 'checkboxes', 'boxes' => call_user_func_array( 'wp_list_pluck', array( array_diff_key( $this->taxonomies, array( 'post_format' => true ) ), 'label' ) ) ) );
+		add_settings_field(
+			'taxonomies', __( 'Add SEO fields to individual:', 'wp-seo' ),
+			array(
+				WP_SEO_Fields(),
+				'field',
+			),
+			$this::SLUG,
+			'taxonomies',
+			array(
+				'field' => 'taxonomies',
+				'type' => 'checkboxes',
+				'boxes' => call_user_func_array(
+					'wp_list_pluck',
+					array(
+						array_diff_key(
+							$this->taxonomies,
+							array(
+								'post_format' => true,
+							)
+						),
+						'label',
+					)
+				),
+			)
+		);
 
 		foreach ( $this->taxonomies as $taxonomy ) {
 			/* translators: %s: taxonomy singular name */
 			add_settings_section( 'taxonomy_' . $taxonomy->name, sprintf( __( '%s Archives', 'wp-seo' ), $taxonomy->labels->singular_name ), array( $this, 'example_term_archive' ), $this::SLUG );
-			add_settings_field( "taxonomy_{$taxonomy->name}_title", __( 'Title Tag Format', 'wp-seo' ), array( WP_SEO_Fields(), 'field' ), $this::SLUG, 'taxonomy_' . $taxonomy->name, array( 'field' => "taxonomy_{$taxonomy->name}_title" ) );
-			add_settings_field( "taxonomy_{$taxonomy->name}_description", __( 'Meta Description Format', 'wp-seo' ), array( WP_SEO_Fields(), 'field' ), $this::SLUG, 'taxonomy_' . $taxonomy->name, array( 'type' => 'textarea', 'field' => "taxonomy_{$taxonomy->name}_description" ) );
-			add_settings_field( "taxonomy_{$taxonomy->name}_keywords", __( 'Meta Keywords Format', 'wp-seo' ), array( WP_SEO_Fields(), 'field' ), $this::SLUG, 'taxonomy_' . $taxonomy->name, array( 'field' => "taxonomy_{$taxonomy->name}_keywords" ) );
+			add_settings_field(
+				"taxonomy_{$taxonomy->name}_title",
+				__(
+					'Title Tag Format',
+					'wp-seo'
+				),
+				array(
+					WP_SEO_Fields(),
+					'field',
+				),
+				$this::SLUG,
+				'taxonomy_' . $taxonomy->name,
+				array(
+					'field' => "taxonomy_{$taxonomy->name}_title",
+				)
+			);
+			add_settings_field(
+				"taxonomy_{$taxonomy->name}_description",
+				__( 'Meta Description Format', 'wp-seo' ),
+				array(
+					WP_SEO_Fields(),
+					'field',
+				),
+				$this::SLUG,
+				'taxonomy_' . $taxonomy->name,
+				array(
+					'type' => 'textarea',
+					'field' => "taxonomy_{$taxonomy->name}_description",
+				)
+			);
+			add_settings_field(
+				"taxonomy_{$taxonomy->name}_keywords",
+				__( 'Meta Keywords Format', 'wp-seo' ),
+				array(
+					WP_SEO_Fields(),
+					'field',
+				),
+				$this::SLUG,
+				'taxonomy_' . $taxonomy->name,
+				array(
+					'field' => "taxonomy_{$taxonomy->name}_keywords",
+				)
+			);
 		}
 
 		add_settings_section( 'archive_author', __( 'Author Archives', 'wp-seo' ), array( $this, 'example_author_archive' ), $this::SLUG );
-		add_settings_field( 'archive_author_title', __( 'Title Tag Format', 'wp-seo' ), array( WP_SEO_Fields(), 'field' ), $this::SLUG, 'archive_author', array( 'field' => 'archive_author_title' ) );
-		add_settings_field( 'archive_author_description', __( 'Meta Description Format', 'wp-seo' ), array( WP_SEO_Fields(), 'field' ), $this::SLUG, 'archive_author', array( 'type' => 'textarea', 'field' => 'archive_author_description' ) );
-		add_settings_field( 'archive_author_keywords', __( 'Meta Keywords Format', 'wp-seo' ), array( WP_SEO_Fields(), 'field' ), $this::SLUG, 'archive_author', array( 'field' => 'archive_author_keywords' ) );
+		add_settings_field(
+			'archive_author_title',
+			__( 'Title Tag Format', 'wp-seo' ),
+			array(
+				WP_SEO_Fields(),
+				'field',
+			),
+			$this::SLUG,
+			'archive_author',
+			array(
+				'field' => 'archive_author_title',
+			)
+		);
+		add_settings_field(
+			'archive_author_description',
+			__( 'Meta Description Format', 'wp-seo' ),
+			array(
+				WP_SEO_Fields(),
+				'field',
+			),
+			$this::SLUG,
+			'archive_author',
+			array(
+				'type' => 'textarea',
+				'field' => 'archive_author_description',
+			)
+		);
+		add_settings_field(
+			'archive_author_keywords',
+			__( 'Meta Keywords Format', 'wp-seo' ),
+			array(
+				WP_SEO_Fields(),
+				'field',
+			),
+			$this::SLUG,
+			'archive_author',
+			array(
+				'field' => 'archive_author_keywords',
+			)
+		);
 
 		add_settings_section( 'archive_date', __( 'Date Archives', 'wp-seo' ), array( $this, 'example_date_archive' ), $this::SLUG );
-		add_settings_field( 'archive_date_title', __( 'Title Tag Format', 'wp-seo' ), array( WP_SEO_Fields(), 'field' ), $this::SLUG, 'archive_date', array( 'field' => 'archive_date_title' ) );
-		add_settings_field( 'archive_date_description', __( 'Meta Description Format', 'wp-seo' ), array( WP_SEO_Fields(), 'field' ), $this::SLUG, 'archive_date', array( 'type' => 'textarea', 'field' => 'archive_date_description' ) );
-		add_settings_field( 'archive_date_keywords', __( 'Meta Keywords Format', 'wp-seo' ), array( WP_SEO_Fields(), 'field' ), $this::SLUG, 'archive_date', array( 'field' => 'archive_date_keywords' ) );
+		add_settings_field(
+			'archive_date_title',
+			__( 'Title Tag Format', 'wp-seo' ),
+			array(
+				WP_SEO_Fields(),
+				'field',
+			),
+			$this::SLUG,
+			'archive_date',
+			array(
+				'field' => 'archive_date_title',
+			)
+		);
+		add_settings_field(
+			'archive_date_description',
+			__( 'Meta Description Format', 'wp-seo' ),
+			array(
+				WP_SEO_Fields(),
+				'field',
+			),
+			$this::SLUG,
+			'archive_date',
+			array(
+				'type' => 'textarea',
+				'field' => 'archive_date_description',
+			)
+		);
+		add_settings_field(
+			'archive_date_keywords',
+			__( 'Meta Keywords Format', 'wp-seo' ),
+			array(
+				WP_SEO_Fields(),
+				'field',
+			),
+			$this::SLUG,
+			'archive_date',
+			array(
+				'field' => 'archive_date_keywords',
+			)
+		);
 
 		add_settings_section( 'search', __( 'Search Results', 'wp-seo' ), array( $this, 'example_search_page' ), $this::SLUG );
-		add_settings_field( 'search_title', __( 'Title Tag Format', 'wp-seo' ), array( WP_SEO_Fields(), 'field' ), $this::SLUG, 'search', array( 'field' => 'search_title' ) );
+		add_settings_field(
+			'search_title',
+			__( 'Title Tag Format', 'wp-seo' ),
+			array(
+				WP_SEO_Fields(),
+				'field'
+			),
+			$this::SLUG,
+			'search',
+			array(
+				'field' => 'search_title',
+			)
+		);
 
 		add_settings_section( '404', __( '404 Page', 'wp-seo' ), array( $this, 'example_404_page' ), $this::SLUG );
-		add_settings_field( '404_title', __( 'Title Tag Format', 'wp-seo' ), array( WP_SEO_Fields(), 'field' ), $this::SLUG, '404', array( 'field' => '404_title' ) );
+		add_settings_field(
+			'404_title',
+			__( 'Title Tag Format', 'wp-seo' ),
+			array(
+				WP_SEO_Fields(),
+				'field',
+			),
+			$this::SLUG,
+			'404',
+			array(
+				'field' => '404_title',
+			)
+		);
 
 		add_settings_section( 'arbitrary', __( 'Other Meta Tags', 'wp-seo' ), false, $this::SLUG );
-		add_settings_field( 'arbitrary_tags', __( 'Tags', 'wp-seo' ), array( WP_SEO_Fields(), 'field' ), $this::SLUG, 'arbitrary', array( 'type' => 'repeatable', 'field' => 'arbitrary_tags', 'repeat' => array( 'name' => __( 'Name', 'lin' ), 'content' => __( 'Content', 'lin' ) ) ) );
+		add_settings_field(
+			'arbitrary_tags',
+			__( 'Tags', 'wp-seo' ),
+			array(
+				WP_SEO_Fields(),
+				'field',
+			),
+			$this::SLUG,
+			'arbitrary',
+			array(
+				'type' => 'repeatable',
+				'field' => 'arbitrary_tags',
+				'repeat' => array(
+					'name' => __( 'Name', 'lin' ),
+					'content' => __( 'Content', 'lin' ),
+				),
+			)
+		);
 	}
 
 	/**

--- a/php/class-wp-seo-settings.php
+++ b/php/class-wp-seo-settings.php
@@ -120,7 +120,6 @@ class WP_SEO_Settings {
 			add_action( 'load-settings_page_' . $this::SLUG, array( $this, 'add_help_tab' ) );
 		}
 		add_filter( 'pre_update_option_' . $this::SLUG, array( $this, 'process_migration' ) );
-		add_filter( 'update_option_' . $this::SLUG, array( $this, 'set_options' ) );
 	}
 
 	/**

--- a/php/class-wp-seo-settings.php
+++ b/php/class-wp-seo-settings.php
@@ -64,14 +64,6 @@ class WP_SEO_Settings {
 	 */
 	public $archived_post_types = array();
 
-	/**
-	 * Taxonomy 'archive' bug fixed.
-	 *
-	 * @var boolean
-	 * @since 0.13.0
-	 */
-	public $taxonomy_migration;
-
 	const SLUG = 'wp-seo';
 
 	/**

--- a/php/class-wp-seo-settings.php
+++ b/php/class-wp-seo-settings.php
@@ -826,7 +826,8 @@ class WP_SEO_Settings {
 	 * @param  array $section An array of settings section data.
 	 */
 	public function example_post_type_archive( $section ) {
-		if ( $url = get_post_type_archive_link( str_replace( 'archive_', '', $section['id'] ) ) ) {
+		$url = get_post_type_archive_link( str_replace( 'archive_', '', $section['id'] ) );
+		if ( $url ) {
 			$this->example_url( __( 'at ', 'wp-seo' ), $url );
 		}
 	}

--- a/php/class-wp-seo-settings.php
+++ b/php/class-wp-seo-settings.php
@@ -478,7 +478,7 @@ class WP_SEO_Settings {
 					'field' => "single_{$post_type->name}_keywords",
 				)
 			);
-		}
+		} // End foreach().
 
 		foreach ( $this->archived_post_types as $post_type ) {
 			/* translators: %s: post type singular name */
@@ -523,7 +523,7 @@ class WP_SEO_Settings {
 					'field' => "archive_{$post_type->name}_keywords",
 				)
 			);
-		}
+		} // End foreach().
 
 		// Post Formats have no UI, so they cannot have per-term fields.
 		add_settings_section( 'taxonomies', __( 'Taxonomies', 'wp-seo' ), '__return_false', $this::SLUG );
@@ -599,7 +599,7 @@ class WP_SEO_Settings {
 					'field' => "taxonomy_{$taxonomy->name}_keywords",
 				)
 			);
-		}
+		} // End foreach().
 
 		add_settings_section( 'archive_author', __( 'Author Archives', 'wp-seo' ), array( $this, 'example_author_archive' ), $this::SLUG );
 		add_settings_field(
@@ -691,7 +691,7 @@ class WP_SEO_Settings {
 			__( 'Title Tag Format', 'wp-seo' ),
 			array(
 				WP_SEO_Fields(),
-				'field'
+				'field',
 			),
 			$this::SLUG,
 			'search',
@@ -772,7 +772,23 @@ class WP_SEO_Settings {
 	 * @param  array $section An array of settings section data.
 	 */
 	public function example_permalink( $section ) {
-		if ( $post = get_posts( array( 'numberposts' => 1, 'post_type' => str_replace( array( 'single_', 'archive_' ), '', $section['id'] ), 'fields' => 'ids', 'suppress_filters' => false ) ) ) {
+		if (
+			$post = get_posts(
+				array(
+					'numberposts' => 1,
+					'post_type' => str_replace(
+						array(
+							'single_',
+							'archive_',
+						),
+						'',
+						$section['id']
+					),
+				'fields' => 'ids',
+				'suppress_filters' => false,
+				)
+			)
+		) {
 			$this->example_url( $this->ex_text(), get_permalink( reset( $post ) ) );
 		} else {
 			$this->example_url( __( 'No posts yet.', 'wp-seo' ) );
@@ -787,7 +803,17 @@ class WP_SEO_Settings {
 	 * @param  array $section An array of settings section data.
 	 */
 	public function example_term_archive( $section ) {
-		if ( $term = get_terms( str_replace( 'taxonomy_', '', $section['id'] ), array( 'number' => 1 ) ) ) {
+		$term = get_terms(
+			str_replace(
+				'taxonomy_',
+				'',
+				$section['id']
+			),
+			array(
+				'number' => 1,
+			)
+		);
+		if ( $term ) {
 			$this->example_url( $this->ex_text(), get_term_link( reset( $term ) ) );
 		} else {
 			$this->example_url( __( 'No terms yet.', 'wp-seo' ) );

--- a/php/class-wp-seo-settings.php
+++ b/php/class-wp-seo-settings.php
@@ -1047,7 +1047,6 @@ class WP_SEO_Settings {
 		endif;
 	}
 }
-
 /**
  * Helper function to use the class instance.
  *

--- a/php/class-wp-seo-settings.php
+++ b/php/class-wp-seo-settings.php
@@ -119,7 +119,6 @@ class WP_SEO_Settings {
 			add_action( 'admin_init', array( $this, 'register_settings' ) );
 			add_action( 'load-settings_page_' . $this::SLUG, array( $this, 'add_help_tab' ) );
 		}
-		add_filter( 'pre_update_option_' . $this::SLUG, array( $this, 'process_migration' ) );
 	}
 
 	/**
@@ -162,26 +161,16 @@ class WP_SEO_Settings {
 		 *
 		 * @param  array Associative array of setting names and values.
 		 */
-		$this->default_options = apply_filters( 'wp_seo_default_options', array( 'post_types' => array_keys( $this->single_post_types ), 'taxonomies' => array_keys( $this->taxonomies ) ) );
-	}
-
-	/**
-	 * Process migration.
-	 *
-	 * @param array $new_value Associative array of new values.
-	 * @param array $old_value Associative array of old values.
-	 * @return array Associative array of filtered values.
-	 */
-	public function process_migration( $new_value, $old_value = array() ) {
-		if ( ! $this->has_taxonomy_migration_run() ) {
-			foreach ( $this->taxonomies as $taxonomy ) {
-				unset( $new_value[ "archive_{$taxonomy->name}_title" ] );
-				unset( $new_value[ "archive_{$taxonomy->name}_description" ] );
-				unset( $new_value[ "archive_{$taxonomy->name}_keywords" ] );
-			}
-			$new_value['internal']['archive_to_taxonomy_migration'] = true;
-		}
-		return $new_value;
+		$this->default_options = apply_filters(
+			'wp_seo_default_options',
+			array(
+				'post_types' => array_keys( $this->single_post_types ),
+				'taxonomies' => array_keys( $this->taxonomies ),
+				'internal'   => array(
+					'archive_to_taxonomy_migration' => true,
+				),
+			)
+		);
 	}
 
 	/**
@@ -584,7 +573,7 @@ class WP_SEO_Settings {
 			$sanitize_as_text_field[] = "single_{$type->name}_keywords";
 		}
 		// Post type, taxonomy, and other archives.
-		foreach ( array_merge( $this->archived_post_types, $this->taxonomies, array( 'author', 'date' ) ) as $type ) {
+		foreach ( array_merge( $this->archived_post_types, array( 'author', 'date' ) ) as $type ) {
 			if ( is_object( $type ) ) {
 				$type = $type->name;
 			}

--- a/php/class-wp-seo.php
+++ b/php/class-wp-seo.php
@@ -463,12 +463,16 @@ if ( ! class_exists( 'WP_SEO' ) ) :
 		public function wp_title( $title, $sep ) {
 			$key = wp_seo_get_key();
 			if ( is_singular() ) {
-				if ( WP_SEO_Settings()->has_post_fields( $post_type = get_post_type() ) && $meta_title = get_post_meta( get_the_ID(), '_meta_title', true ) ) {
+				$meta_title = get_post_meta( get_the_ID(), '_meta_title', true );
+				 $post_type = get_post_type();
+				if ( WP_SEO_Settings()->has_post_fields( $post_type ) && $meta_title ) {
 					$title_tag = $this->format( $meta_title );
 					$key = false;
 				}
 			} elseif ( is_category() || is_tag() || is_tax() ) {
-				if ( ( WP_SEO_Settings()->has_term_fields( $taxonomy = get_queried_object()->taxonomy ) ) && ( $option = get_option( $this->get_term_option_name( get_queried_object() ) ) ) && ( ! empty( $option['title'] ) ) ) {
+				$taxonomy = get_queried_object()->taxonomy;
+				$option = get_option( $this->get_term_option_name( get_queried_object() ) );
+				if ( ( WP_SEO_Settings()->has_term_fields( $taxonomy ) ) && $option && ( ! empty( $option['title'] ) ) ) {
 					$title_tag = $this->format( $option['title'] );
 					$key = false;
 				}
@@ -543,12 +547,15 @@ if ( ! class_exists( 'WP_SEO' ) ) :
 			$key = wp_seo_get_key();
 
 			if ( is_singular() ) {
-				if ( WP_SEO_Settings()->has_post_fields( $post_type = get_post_type() ) ) {
+				$post_type = get_post_type();
+				if ( WP_SEO_Settings()->has_post_fields( $post_type ) ) {
 					$meta_description = $this->format( get_post_meta( get_the_ID(), '_meta_description', true ) );
 					$meta_keywords = $this->format( get_post_meta( get_the_ID(), '_meta_keywords', true ) );
 				}
 			} elseif ( is_category() || is_tag() || is_tax() ) {
-				if ( WP_SEO_Settings()->has_term_fields( $taxonomy = get_queried_object()->taxonomy ) && $option = get_option( $this->get_term_option_name( get_queried_object() ) ) ) {
+				$taxonomy = get_queried_object()->taxonomy;
+				$option = get_option( $this->get_term_option_name( get_queried_object() ) );
+				if ( WP_SEO_Settings()->has_term_fields( $taxonomy ) && $option ) {
 					if ( isset( $option['description'] ) ) {
 						$meta_description = $this->format( $option['description'] );
 					}

--- a/php/class-wp-seo.php
+++ b/php/class-wp-seo.php
@@ -464,7 +464,7 @@ if ( ! class_exists( 'WP_SEO' ) ) :
 			$key = wp_seo_get_key();
 			if ( is_singular() ) {
 				$meta_title = get_post_meta( get_the_ID(), '_meta_title', true );
-				 $post_type = get_post_type();
+				$post_type = get_post_type();
 				if ( WP_SEO_Settings()->has_post_fields( $post_type ) && $meta_title ) {
 					$title_tag = $this->format( $meta_title );
 					$key = false;

--- a/php/general-functions.php
+++ b/php/general-functions.php
@@ -33,6 +33,11 @@ function wp_seo_get_key( $query = false ) {
 		global $wp_query;
 		$query = $wp_query;
 	}
+	if ( WP_SEO_Settings()->has_taxonomy_migration_run() ) {
+		$taxonomy_slug = 'taxonomy';
+	} else {
+		$taxonomy_slug = 'archive';
+	}
 	if ( $query->is_singular() ) {
 		$post_type = get_post_type( get_queried_object() );
 		$key = "single_{$post_type}";
@@ -42,7 +47,7 @@ function wp_seo_get_key( $query = false ) {
 		$key = 'archive_author';
 	} elseif ( $query->is_category() || $query->is_tag() || $query->is_tax() ) {
 		$taxonomy = get_queried_object()->taxonomy;
-		$key = "taxonomy_{$taxonomy}";
+		$key = "{$taxonomy_slug}_{$taxonomy}";
 	} elseif ( $query->is_post_type_archive() ) {
 		$key = 'archive_' . get_queried_object()->name;
 	} elseif ( $query->is_date() ) {

--- a/php/general-functions.php
+++ b/php/general-functions.php
@@ -42,7 +42,7 @@ function wp_seo_get_key( $query = false ) {
 		$key = 'archive_author';
 	} elseif ( $query->is_category() || $query->is_tag() || $query->is_tax() ) {
 		$taxonomy = get_queried_object()->taxonomy;
-		$key = "archive_{$taxonomy}";
+		$key = "taxonomy_{$taxonomy}";
 	} elseif ( $query->is_post_type_archive() ) {
 		$key = 'archive_' . get_queried_object()->name;
 	} elseif ( $query->is_date() ) {

--- a/phpcs.ruleset.xml
+++ b/phpcs.ruleset.xml
@@ -7,6 +7,6 @@
 
 	<rule ref="WordPress">
 		<!-- This plugin can be used in environments without wpcom_vip_get_term_link(). -->
-		<exclude name="WordPress.VIP.RestrictedFunctions.get_term_link" />
+		<exclude name="WordPress.VIP.RestrictedFunctions.get_term_link_get_term_link" />
 	</rule>
 </ruleset>

--- a/tests/test-has-fields.php
+++ b/tests/test-has-fields.php
@@ -25,9 +25,7 @@ class WP_SEO_Has_Fields_Tests extends WP_UnitTestCase {
 		$this->assertTrue( WP_SEO_Settings()->has_post_fields( 'post' ) );
 		$this->assertFalse( WP_SEO_Settings()->has_post_fields( 'page' ) );
 	}
-	/**
-	 * @group failing
-	 */
+
 	function test_has_term_fields() {
 		$this->assertTrue( WP_SEO_Settings()->has_term_fields( 'category' ) );
 		$this->assertFalse( WP_SEO_Settings()->has_term_fields( 'post_tag' ) );

--- a/tests/test-has-fields.php
+++ b/tests/test-has-fields.php
@@ -12,6 +12,7 @@ class WP_SEO_Has_Fields_Tests extends WP_UnitTestCase {
 			'post_types' => array( 'post' ),
 			'taxonomies' => array( 'category' ),
 		) );
+		WP_SEO_Settings()->set_options();
 	}
 
 	function tearDown() {
@@ -24,7 +25,9 @@ class WP_SEO_Has_Fields_Tests extends WP_UnitTestCase {
 		$this->assertTrue( WP_SEO_Settings()->has_post_fields( 'post' ) );
 		$this->assertFalse( WP_SEO_Settings()->has_post_fields( 'page' ) );
 	}
-
+	/**
+	 * @group failing
+	 */
 	function test_has_term_fields() {
 		$this->assertTrue( WP_SEO_Settings()->has_term_fields( 'category' ) );
 		$this->assertFalse( WP_SEO_Settings()->has_term_fields( 'post_tag' ) );

--- a/tests/test-settings-page.php
+++ b/tests/test-settings-page.php
@@ -91,7 +91,7 @@ class WP_SEO_Settings_Page_Tests extends WP_UnitTestCase {
 		$category_id = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
 		wp_set_object_terms( $this->factory->post->create(), $category_id, 'category' );
 
-		$section = array( 'id' => 'archive_category' );
+		$section = array( 'id' => 'taxonomy_category' );
 		$html = get_echo( array( WP_SEO_Settings(), 'example_term_archive' ), array( $section ) );
 
 		$this->assertContains( get_term_link( $category_id, 'category' ), $html );
@@ -103,7 +103,7 @@ class WP_SEO_Settings_Page_Tests extends WP_UnitTestCase {
 	function test_example_term_archive_no_terms() {
 		register_taxonomy( 'demo', 'post' );
 
-		$section = array( 'id' => 'archive_demo' );
+		$section = array( 'id' => 'taxonomy_demo' );
 		$html = get_echo( array( WP_SEO_Settings(), 'example_term_archive' ), array( $section ) );
 
 		$this->assertContains( 'No terms yet.', $html );

--- a/tests/test-taxonomy-migration.php
+++ b/tests/test-taxonomy-migration.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Tests WP SEO migration.
+ *
+ * @package WP SEO
+ */
+class WP_SEO_Taxonomy_Migration_Test extends WP_UnitTestCase {
+
+	function tearDown() {
+		parent::tearDown();
+		delete_option( WP_SEO_Settings::SLUG );
+	}
+
+	function test_has_not_migrated() {
+		$this->assertFalse( WP_SEO_Settings()->has_taxonomy_migration_run() );
+	}
+
+	function test_has_migrated() {
+		update_option( WP_SEO_Settings::SLUG, array(
+			'post_types' => array( 'post' ),
+			'taxonomies' => array( 'category' ),
+		) );
+		WP_SEO_Settings()->set_options();
+		$this->assertTrue( WP_SEO_Settings()->has_taxonomy_migration_run() );
+	}
+}

--- a/tests/test-taxonomy-migration.php
+++ b/tests/test-taxonomy-migration.php
@@ -6,20 +6,15 @@
  */
 class WP_SEO_Taxonomy_Migration_Test extends WP_UnitTestCase {
 
-	function tearDown() {
-		parent::tearDown();
-		delete_option( WP_SEO_Settings::SLUG );
-	}
-
 	function test_has_not_migrated() {
 		$this->assertFalse( WP_SEO_Settings()->has_taxonomy_migration_run() );
 	}
 
 	function test_has_migrated() {
-		update_option( WP_SEO_Settings::SLUG, array(
+		update_option( WP_SEO_Settings::SLUG, WP_SEO_Settings()->sanitize_options( array(
 			'post_types' => array( 'post' ),
 			'taxonomies' => array( 'category' ),
-		) );
+		) ) );
 		WP_SEO_Settings()->set_options();
 		$this->assertTrue( WP_SEO_Settings()->has_taxonomy_migration_run() );
 	}

--- a/tests/test-wp-title-wp-head.php
+++ b/tests/test-wp-title-wp-head.php
@@ -69,7 +69,6 @@ class WP_SEO_WP_Title_WP_Head_Tests extends WP_UnitTestCase {
 			$this->options[ "{$key}_description" ] = "demo_{$key}_description";
 			$this->options[ "{$key}_keywords" ]    = "demo_{$key}_keywords";
 		}
-
 		update_option( WP_SEO_Settings::SLUG, WP_SEO_Settings()->sanitize_options( $this->options ) );
 	}
 
@@ -184,13 +183,18 @@ EOF;
 		$this->go_to( get_author_posts_url( $author_id ) );
 		$this->_assert_option_filters( 'archive_author' );
 	}
-
+	/**
+	 * @group failing
+	 */
 	function test_category() {
 		$category_id = $this->factory->term->create( array( 'name' => 'cat-a', 'taxonomy' => 'category' ) );
 		$this->go_to( get_term_link( $category_id, 'category' ) );
 		$this->_assert_option_filters( 'taxonomy_category' );
 	}
 
+	/**
+	 * @group failing
+	 */
 	function test_tax() {
 		$term_id = $this->factory->term->create( array( 'name' => 'demo-a', 'taxonomy' => $this->taxonomy ) );
 		$this->go_to( get_term_link( $term_id, $this->taxonomy ) );

--- a/tests/test-wp-title-wp-head.php
+++ b/tests/test-wp-title-wp-head.php
@@ -183,18 +183,13 @@ EOF;
 		$this->go_to( get_author_posts_url( $author_id ) );
 		$this->_assert_option_filters( 'archive_author' );
 	}
-	/**
-	 * @group failing
-	 */
+
 	function test_category() {
 		$category_id = $this->factory->term->create( array( 'name' => 'cat-a', 'taxonomy' => 'category' ) );
 		$this->go_to( get_term_link( $category_id, 'category' ) );
 		$this->_assert_option_filters( 'taxonomy_category' );
 	}
 
-	/**
-	 * @group failing
-	 */
 	function test_tax() {
 		$term_id = $this->factory->term->create( array( 'name' => 'demo-a', 'taxonomy' => $this->taxonomy ) );
 		$this->go_to( get_term_link( $term_id, $this->taxonomy ) );

--- a/tests/test-wp-title-wp-head.php
+++ b/tests/test-wp-title-wp-head.php
@@ -57,8 +57,8 @@ class WP_SEO_WP_Title_WP_Head_Tests extends WP_UnitTestCase {
 			'single_post',
 			"single_{$this->post_type}",
 			'archive_author',
-			'archive_category',
-			"archive_{$this->taxonomy}",
+			'taxonomy_category',
+			"taxonomy_{$this->taxonomy}",
 			"archive_{$this->post_type}",
 			'archive_date',
 			'search',
@@ -188,13 +188,13 @@ EOF;
 	function test_category() {
 		$category_id = $this->factory->term->create( array( 'name' => 'cat-a', 'taxonomy' => 'category' ) );
 		$this->go_to( get_term_link( $category_id, 'category' ) );
-		$this->_assert_option_filters( 'archive_category' );
+		$this->_assert_option_filters( 'taxonomy_category' );
 	}
 
 	function test_tax() {
 		$term_id = $this->factory->term->create( array( 'name' => 'demo-a', 'taxonomy' => $this->taxonomy ) );
 		$this->go_to( get_term_link( $term_id, $this->taxonomy ) );
-		$this->_assert_option_filters( "archive_{$this->taxonomy}" );
+		$this->_assert_option_filters( "taxonomy_{$this->taxonomy}" );
 	}
 
 	// A term with custom values should not use the archive_{taxonomy}_ fields.

--- a/wp-seo.php
+++ b/wp-seo.php
@@ -43,7 +43,7 @@ require_once WP_SEO_PATH . '/php/class-wp-seo-settings.php';
 require_once WP_SEO_PATH . '/php/class-wp-seo-formatting-tag.php';
 
 // Included formatting tags.
-require_once WP_SEO_PATH . '/php/default-formatting-tags.php';
+require_once WP_SEO_PATH . '/php/class-wp-seo-format-site-name.php';
 
 // General functions.
 require_once WP_SEO_PATH . '/php/general-functions.php';


### PR DESCRIPTION
Identified by @dlh01, right now post types and taxonomies share the same namespace. This patch handles migrating legacy data to a new taxonomy specific namespace. https://github.com/alleyinteractive/wp-seo/pull/72#issuecomment-287625525