### PR TITLE
Introduce `should_taxonomy_migration_run()` method

### DIFF
--- a/php/class-wp-seo-fields.php
+++ b/php/class-wp-seo-fields.php
@@ -77,6 +77,11 @@ class WP_SEO_Fields {
 		if ( empty( $args['type'] ) ) {
 			$args['type'] = 'text';
 		}
+
+		/*
+		 * If the migration has not run and it should run,
+		 * place the contents of legacy fields in new fields.
+		*/
 		if (
 			! WP_SEO_Settings()->has_taxonomy_migration_run() &&
 			WP_SEO_Settings()->should_taxonomy_migration_run() &&

--- a/php/class-wp-seo-fields.php
+++ b/php/class-wp-seo-fields.php
@@ -81,7 +81,7 @@ class WP_SEO_Fields {
 		/*
 		 * If the migration has not run and it should run,
 		 * place the contents of legacy fields in new fields.
-		*/
+		 */
 		if (
 			! WP_SEO_Settings()->has_taxonomy_migration_run() &&
 			WP_SEO_Settings()->should_taxonomy_migration_run() &&

--- a/php/class-wp-seo-fields.php
+++ b/php/class-wp-seo-fields.php
@@ -79,6 +79,7 @@ class WP_SEO_Fields {
 		}
 		if (
 			! WP_SEO_Settings()->has_taxonomy_migration_run() &&
+			WP_SEO_Settings()->should_taxonomy_migration_run() &&
 			substr( $args['field'], 0, 9 ) === 'taxonomy_' &&
 			array_filter(
 				array_map(

--- a/php/class-wp-seo-settings.php
+++ b/php/class-wp-seo-settings.php
@@ -326,7 +326,7 @@ class WP_SEO_Settings {
 	 * @return bool
 	 */
 	public function should_taxonomy_migration_run() {
-		return apply_filters( 'wp_seo_taxonomy_migration_opt_in', false );
+		return (bool) apply_filters( 'wp_seo_should_taxonomy_migration_run', false );
 	}
 
 	/**
@@ -1052,7 +1052,7 @@ class WP_SEO_Settings {
 		/*
 		 * If the migration has not run and should not run,
 		 * update the internal option to make it explicit.
-		*/
+		 */
 		if ( ! $this->has_taxonomy_migration_run() && ! $this->should_taxonomy_migration_run() ) {
 			$out['internal']['archive_to_taxonomy_migration'] = false;
 		}

--- a/php/class-wp-seo-settings.php
+++ b/php/class-wp-seo-settings.php
@@ -562,7 +562,7 @@ class WP_SEO_Settings {
 			)
 		);
 
-		if ( $this->has_taxonomy_migration_run() && $this->should_taxonomy_migration_run() ) {
+		if ( $this->has_taxonomy_migration_run() || $this->should_taxonomy_migration_run() ) {
 			$prefix = 'taxonomy';
 		} else {
 			$prefix = 'archive';
@@ -972,7 +972,7 @@ class WP_SEO_Settings {
 			$sanitize_as_text_field[] = "archive_{$type}_description";
 			$sanitize_as_text_field[] = "archive_{$type}_keywords";
 		}
-		if ( $this->has_taxonomy_migration_run() && $this->should_taxonomy_migration_run() ) {
+		if ( $this->has_taxonomy_migration_run() || $this->should_taxonomy_migration_run() ) {
 			$prefix = 'taxonomy';
 		} else {
 			$prefix = 'archive';
@@ -1037,6 +1037,9 @@ class WP_SEO_Settings {
 				// Remove groups with only empty fields.
 				$out[ $repeatable ] = array_filter( $out[ $repeatable ] );
 			}
+		}
+		if ( ! $this->should_taxonomy_migration_run() ) {
+			$out['internal']['archive_to_taxonomy_migration'] = false;
 		}
 		return $out;
 	}

--- a/php/class-wp-seo-settings.php
+++ b/php/class-wp-seo-settings.php
@@ -321,6 +321,15 @@ class WP_SEO_Settings {
 	}
 
 	/**
+	 * Helper to see whether the 'archive' to 'taxonomy' migration should run.
+	 *
+	 * @return bool
+	 */
+	public function should_taxonomy_migration_run() {
+		return apply_filters( 'wp_seo_taxonomy_migration_opt_in', false );
+	}
+
+	/**
 	 * Helper to see whether the 'archive' to 'taxonomy' migration has run.
 	 *
 	 * @return bool

--- a/php/class-wp-seo-settings.php
+++ b/php/class-wp-seo-settings.php
@@ -565,7 +565,7 @@ class WP_SEO_Settings {
 		/*
 		 * If the migration has run or should run,
 		 * we'll find taxonomy data in new fields.
-		*/
+		 */
 		if ( $this->has_taxonomy_migration_run() || $this->should_taxonomy_migration_run() ) {
 			$prefix = 'taxonomy';
 		} else {
@@ -980,7 +980,7 @@ class WP_SEO_Settings {
 		/*
 		 * If the migration has run or should run,
 		 * we'll find taxonomy data in new fields.
-		*/
+		 */
 		if ( $this->has_taxonomy_migration_run() || $this->should_taxonomy_migration_run() ) {
 			$prefix = 'taxonomy';
 		} else {

--- a/php/class-wp-seo-settings.php
+++ b/php/class-wp-seo-settings.php
@@ -1038,7 +1038,7 @@ class WP_SEO_Settings {
 				$out[ $repeatable ] = array_filter( $out[ $repeatable ] );
 			}
 		}
-		if ( ! $this->should_taxonomy_migration_run() ) {
+		if ( ! $this->has_taxonomy_migration_run() && ! $this->should_taxonomy_migration_run() ) {
 			$out['internal']['archive_to_taxonomy_migration'] = false;
 		}
 		return $out;

--- a/php/class-wp-seo-settings.php
+++ b/php/class-wp-seo-settings.php
@@ -562,6 +562,10 @@ class WP_SEO_Settings {
 			)
 		);
 
+		/*
+		 * If the migration has run or should run,
+		 * we'll find taxonomy data in new fields.
+		*/
 		if ( $this->has_taxonomy_migration_run() || $this->should_taxonomy_migration_run() ) {
 			$prefix = 'taxonomy';
 		} else {
@@ -972,6 +976,11 @@ class WP_SEO_Settings {
 			$sanitize_as_text_field[] = "archive_{$type}_description";
 			$sanitize_as_text_field[] = "archive_{$type}_keywords";
 		}
+
+		/*
+		 * If the migration has run or should run,
+		 * we'll find taxonomy data in new fields.
+		*/
 		if ( $this->has_taxonomy_migration_run() || $this->should_taxonomy_migration_run() ) {
 			$prefix = 'taxonomy';
 		} else {
@@ -1038,6 +1047,12 @@ class WP_SEO_Settings {
 				$out[ $repeatable ] = array_filter( $out[ $repeatable ] );
 			}
 		}
+
+
+		/*
+		 * If the migration has not run and should not run,
+		 * update the internal option to make it explicit.
+		*/
 		if ( ! $this->has_taxonomy_migration_run() && ! $this->should_taxonomy_migration_run() ) {
 			$out['internal']['archive_to_taxonomy_migration'] = false;
 		}

--- a/php/class-wp-seo-settings.php
+++ b/php/class-wp-seo-settings.php
@@ -562,11 +562,16 @@ class WP_SEO_Settings {
 			)
 		);
 
+		if ( $this->has_taxonomy_migration_run() && $this->should_taxonomy_migration_run() ) {
+			$prefix = 'taxonomy';
+		} else {
+			$prefix = 'archive';
+		}
 		foreach ( $this->taxonomies as $taxonomy ) {
 			/* translators: %s: taxonomy singular name */
 			add_settings_section( 'taxonomy_' . $taxonomy->name, sprintf( __( '%s Archives', 'wp-seo' ), $taxonomy->labels->singular_name ), array( $this, 'example_term_archive' ), $this::SLUG );
 			add_settings_field(
-				"taxonomy_{$taxonomy->name}_title",
+				"{$prefix}_{$taxonomy->name}_title",
 				__(
 					'Title Tag Format',
 					'wp-seo'
@@ -576,36 +581,36 @@ class WP_SEO_Settings {
 					'field',
 				),
 				$this::SLUG,
-				'taxonomy_' . $taxonomy->name,
+				"{$prefix}_{$taxonomy->name}",
 				array(
-					'field' => "taxonomy_{$taxonomy->name}_title",
+					'field' => "{$prefix}_{$taxonomy->name}_title",
 				)
 			);
 			add_settings_field(
-				"taxonomy_{$taxonomy->name}_description",
+				"{$prefix}_{$taxonomy->name}_description",
 				__( 'Meta Description Format', 'wp-seo' ),
 				array(
 					WP_SEO_Fields(),
 					'field',
 				),
 				$this::SLUG,
-				'taxonomy_' . $taxonomy->name,
+				"{$prefix}_{$taxonomy->name}",
 				array(
 					'type' => 'textarea',
-					'field' => "taxonomy_{$taxonomy->name}_description",
+					'field' => "{$prefix}_{$taxonomy->name}_description",
 				)
 			);
 			add_settings_field(
-				"taxonomy_{$taxonomy->name}_keywords",
+				"{$prefix}_{$taxonomy->name}_keywords",
 				__( 'Meta Keywords Format', 'wp-seo' ),
 				array(
 					WP_SEO_Fields(),
 					'field',
 				),
 				$this::SLUG,
-				'taxonomy_' . $taxonomy->name,
+				"{$prefix}_{$taxonomy->name}",
 				array(
-					'field' => "taxonomy_{$taxonomy->name}_keywords",
+					'field' => "{$prefix}_{$taxonomy->name}_keywords",
 				)
 			);
 		} // End foreach().
@@ -967,13 +972,18 @@ class WP_SEO_Settings {
 			$sanitize_as_text_field[] = "archive_{$type}_description";
 			$sanitize_as_text_field[] = "archive_{$type}_keywords";
 		}
+		if ( $this->has_taxonomy_migration_run() && $this->should_taxonomy_migration_run() ) {
+			$prefix = 'taxonomy';
+		} else {
+			$prefix = 'archive';
+		}
 		foreach ( $this->taxonomies as $type ) {
 			if ( is_object( $type ) ) {
 				$type = $type->name;
 			}
-			$sanitize_as_text_field[] = "taxonomy_{$type}_title";
-			$sanitize_as_text_field[] = "taxonomy_{$type}_description";
-			$sanitize_as_text_field[] = "taxonomy_{$type}_keywords";
+			$sanitize_as_text_field[] = "{$prefix}_{$type}_title";
+			$sanitize_as_text_field[] = "{$prefix}_{$type}_description";
+			$sanitize_as_text_field[] = "{$prefix}_{$type}_keywords";
 		}
 		// "Other Pages" titles.
 		$sanitize_as_text_field[] = 'search_title';

--- a/tests/test-taxonomy-migration.php
+++ b/tests/test-taxonomy-migration.php
@@ -22,9 +22,7 @@ class WP_SEO_Taxonomy_Migration_Test extends WP_UnitTestCase {
 	}
 
 	function test_should_migration_run_with_filter() {
-		add_filter( 'wp_seo_taxonomy_migration_opt_in', function() {
-			return true;
-		});
+		add_filter( 'wp_seo_should_taxonomy_migration_run', '__return_true' );
 		$this->assertTrue( WP_SEO_Settings()->should_taxonomy_migration_run() );
 	}
 

--- a/tests/test-taxonomy-migration.php
+++ b/tests/test-taxonomy-migration.php
@@ -6,19 +6,30 @@
  */
 class WP_SEO_Taxonomy_Migration_Test extends WP_UnitTestCase {
 
-	function test_should_not_migrate() {
+	function setUp() {
+		parent::setUp();
+		delete_option( WP_SEO_Settings::SLUG );
+		WP_SEO_Settings()->set_options();
+	}
+
+	function tearDown() {
+		parent::tearDown();
+		delete_option( WP_SEO_Settings::SLUG );
+	}
+
+	function test_should_migration_run() {
 		$this->assertFalse( WP_SEO_Settings()->should_taxonomy_migration_run() );
 	}
 
-	function test_should_migrate() {
+	function test_should_migration_run_with_filter() {
 		add_filter( 'wp_seo_taxonomy_migration_opt_in', function() {
 			return true;
 		});
 		$this->assertTrue( WP_SEO_Settings()->should_taxonomy_migration_run() );
 	}
 
-	function test_has_not_migrated() {
-		$this->assertFalse( WP_SEO_Settings()->has_taxonomy_migration_run() );
+	function test_new_site_has_migrated() {
+		$this->assertTrue( WP_SEO_Settings()->has_taxonomy_migration_run() );
 	}
 
 	function test_has_migrated() {

--- a/tests/test-taxonomy-migration.php
+++ b/tests/test-taxonomy-migration.php
@@ -6,6 +6,17 @@
  */
 class WP_SEO_Taxonomy_Migration_Test extends WP_UnitTestCase {
 
+	function test_should_not_migrate() {
+		$this->assertFalse( WP_SEO_Settings()->should_taxonomy_migration_run() );
+	}
+
+	function test_should_migrate() {
+		add_filter( 'wp_seo_taxonomy_migration_opt_in', function() {
+			return true;
+		});
+		$this->assertTrue( WP_SEO_Settings()->should_taxonomy_migration_run() );
+	}
+
 	function test_has_not_migrated() {
 		$this->assertFalse( WP_SEO_Settings()->has_taxonomy_migration_run() );
 	}


### PR DESCRIPTION
An existing implementation of WP SEO will now require the use of a filter to opt in to migration.