### PR TITLE
Remove `WP_SEO_Settings::set_option()`

### DIFF
--- a/php/class-wp-seo-settings.php
+++ b/php/class-wp-seo-settings.php
@@ -223,16 +223,6 @@ class WP_SEO_Settings {
 	}
 
 	/**
-	 * Override the value of an option in the variable.
-	 *
-	 * @param string $key     The option key sought.
-	 * @param mixed  $value   The option value.
-	 */
-	public function set_option( $key, $value ) {
-		$this->options[ $key ] = $value;
-	}
-
-	/**
 	 * Get an option value.
 	 *
 	 * @param string $key     The option key sought.

--- a/tests/test-settings-page.php
+++ b/tests/test-settings-page.php
@@ -184,8 +184,9 @@ class WP_SEO_Settings_Page_Tests extends WP_UnitTestCase {
 		$this->assertRegExp( '/<input[^>]+type="text"[^>]+name="wp-seo\[demo\]"/', $html );
 
 		// Check that a value is passed.
-		WP_SEO_Settings()->set_option( 'demo', 'demo value' );
-		$html = get_echo( array( WP_SEO_Fields(), 'field' ), array( array( 'field' => 'demo' ) ) );
+		update_option( WP_SEO_Settings::SLUG, array( 'home_title' => 'demo value' ) );
+		WP_SEO_Settings()->set_options();
+		$html = get_echo( array( WP_SEO_Fields(), 'field' ), array( array( 'field' => 'home_title' ) ) );
 		$this->assertRegExp( '/<input[^>]+type="text"[^>]+value="demo value"/', $html );
 
 		// Check the rendered field types.


### PR DESCRIPTION
The `options` property is supposed to represent the "current option values of the plugin," so it's not intended to be so easily amended. Also update a test that violates this spirit.

Side note: I think there's an argument for deprecating the `$options` property entirely. Storing our own copy of the option value is asking for trouble given that the plugin doesn't update the property when the option itself updates. We could potentially replace it with a `__get()` magic method that just calls `get_option()`.