### PR TITLE
Add the ability to register additional SEO meta keys

### DIFF
--- a/php/class-wp-seo-settings.php
+++ b/php/class-wp-seo-settings.php
@@ -984,7 +984,7 @@ class WP_SEO_Settings {
 		}
 
 		foreach ( $sanitize_as_integer as $field ) {
-			$out[ $field ] = isset( $in[ $field ] ) && is_int( intval( $in[ $field ] ) ) ? intval( $in[ $field ] ) : null;
+			$out[ $field ] = isset( $in[ $field ] ) && is_int( intval( $in[ $field ] ) ) ? wp_seo_sanitize_integer_field( $in[ $field ] ) : null;
 		}
 
 		/**

--- a/php/class-wp-seo-settings.php
+++ b/php/class-wp-seo-settings.php
@@ -984,7 +984,7 @@ class WP_SEO_Settings {
 		}
 
 		foreach ( $sanitize_as_integer as $field ) {
-			$out[ $field ] = isset( $in[ $field ] ) && is_int( intval( $in[ $field ] ) ) ? wp_seo_sanitize_integer_field( $in[ $field ] ) : null;
+			$out[ $field ] = isset( $in[ $field ] ) ? wp_seo_sanitize_integer_field( $in[ $field ] ) : null;
 		}
 
 		/**

--- a/php/class-wp-seo.php
+++ b/php/class-wp-seo.php
@@ -208,20 +208,11 @@ if ( ! class_exists( 'WP_SEO' ) ) :
 		 * @return array Option values with default keys and values.
 		 */
 		public function intersect_term_option( $option_value ) {
-			/**
-			 * Filter the fields that will be intersected with term options.
-			 *
-			 * @param array Array of fields to intersect.
-			 */
-			$term_fields = apply_filters(
-				'wp_seo_intersect_term_option',
-				array(
-					'title'       => '',
-					'description' => '',
-					'keywords'    => '',
-				)
-			);
-			return wp_seo_intersect_args( $option_value, $term_fields );
+			return wp_seo_intersect_args( $option_value, array(
+				'title'       => '',
+				'description' => '',
+				'keywords'    => '',
+			) );
 		}
 
 		/**

--- a/php/class-wp-seo.php
+++ b/php/class-wp-seo.php
@@ -32,17 +32,6 @@ if ( ! class_exists( 'WP_SEO' ) ) :
 		public $formatting_tag_pattern = '';
 
 		/**
-		 * The fields whitelisted for use.
-		 *
-		 * @var string.
-		 */
-		public $whitelisted_fields = array(
-			'title',
-			'description',
-			'keywords',
-		);
-
-		/**
 		 * Unused.
 		 *
 		 * @codeCoverageIgnore
@@ -132,17 +121,6 @@ if ( ! class_exists( 'WP_SEO' ) ) :
 			 * @param string WP_SEO::formatting_tag_pattern The regex.
 			 */
 			$this->formatting_tag_pattern = apply_filters( 'wp_seo_formatting_tag_pattern', '/#[a-zA-Z\_]+#/' );
-
-			/**
-			 * Filters the whitelisted fields.
-			 *
-			 * You might need this if you have added other fields.
-			 *
-			 * @since 0.13.0
-			 *
-			 * @param string WP_SEO::whitelisted_fields The built-in fields
-			 */
-			$this->whitelisted_fields = apply_filters( 'wp_seo_whitelisted_fields', $this->whitelisted_fields );
 		}
 
 		/**
@@ -273,7 +251,7 @@ if ( ! class_exists( 'WP_SEO' ) ) :
 			if ( ! isset( $_POST['seo_meta'] ) ) {
 				$_POST['seo_meta'] = array();
 			}
-			foreach ( $this->whitelisted_fields as $field ) {
+			foreach ( array( 'title', 'description', 'keywords' ) as $field ) {
 				$data = isset( $_POST['seo_meta'][ $field ] ) ? sanitize_text_field( wp_unslash( $_POST['seo_meta'][ $field ] ) ) : '';
 				update_post_meta( $post_id, wp_slash( '_meta_' . $field ), wp_slash( $data ) );
 			}
@@ -375,7 +353,7 @@ if ( ! class_exists( 'WP_SEO' ) ) :
 				$_POST['seo_meta'] = array();
 			}
 
-			foreach ( $this->whitelisted_fields as $field ) {
+			foreach ( array( 'title', 'description', 'keywords' ) as $field ) {
 				$data[ $field ] = isset( $_POST['seo_meta'][ $field ] ) ? sanitize_text_field( wp_unslash( $_POST['seo_meta'][ $field ] ) ) : '';
 			}
 

--- a/php/formatting-functions.php
+++ b/php/formatting-functions.php
@@ -62,3 +62,31 @@ function wp_seo_get_the_display_character_count( $string ) {
 
 	return (string) strlen( $string );
 }
+
+/**
+ * Sanitizes a submitted variable into an integer after casting as string for consistency.
+ *
+ * @param mixed $input The input's current value.
+ * @return int $input The sanitized value, or 0 on failure.
+ */
+function wp_seo_sanitize_integer_field( $input ) {
+	if ( ! function_exists( 'ctype_digit' ) || ! defined( 'FILTER_SANITIZE_NUMBER_INT' ) ) {
+		return intval( $input );
+	}
+
+	if ( ! is_scalar( $input ) ) {
+		if ( is_object( $input ) ) {
+			return 0;
+		}
+
+		$input = intval( $input );
+	}
+
+	$input = (string) $input;
+
+	if ( ! ctype_digit( $input ) ) {
+		return 0;
+	}
+
+	return (int) filter_var( $input, FILTER_SANITIZE_NUMBER_INT );
+}

--- a/tests/test-formatting-functions.php
+++ b/tests/test-formatting-functions.php
@@ -120,4 +120,33 @@ class WP_SEO_Formatting_Functions_Tests extends WP_SEO_Testcase {
 			array( '#helloworld#' ),
 		);
 	}
+
+	/**
+	 * Test wp_seo_sanitize_integer_field() with various inputs.
+	 *
+	 * @dataProvider data_sanitize_integer_field_inputs
+	 */
+	public function test_sanitize_integer_field( $input, $expected ) {
+		$this->assertSame( $expected, wp_seo_sanitize_integer_field( $input ) );
+	}
+
+	/**
+	 * @return array {
+	 *     @type mixed Value to sanitize.
+	 *     @type int The expected sanitized value.
+	 * }
+	 */
+	public function data_integer_field_inputs() {
+		return array(
+			array( 2, 2 ),
+			array( '3', 3 ),
+			array( 'foo', 0 ),
+			array( '+42', 0 ),
+			array( '-42', 0 ),
+			array( -42, 0 ),
+			array( array(), 0 ),
+			array( array( 'foo', 'bar' ), 1 ),
+			array( new WP_Error, 0 ),
+		);
+	}
 }

--- a/tests/test-formatting-functions.php
+++ b/tests/test-formatting-functions.php
@@ -136,7 +136,7 @@ class WP_SEO_Formatting_Functions_Tests extends WP_SEO_Testcase {
 	 *     @type int The expected sanitized value.
 	 * }
 	 */
-	public function data_integer_field_inputs() {
+	public function data_sanitize_integer_field_inputs() {
 		return array(
 			array( 2, 2 ),
 			array( '3', 3 ),

--- a/tests/test-wp-seo.php
+++ b/tests/test-wp-seo.php
@@ -46,6 +46,43 @@ class WP_SEO_WP_SEO_Tests extends WP_SEO_Testcase {
 			WP_SEO::instance()->intersect_term_option( array() ),
 			'Unexpectedly missing default term option key'
 		);
+	}
 
+	public function test_register_meta_registers_callbacks() {
+		$meta_key = rand_str();
+		$object_type = 'foo';
+		$auth_callback = 'is_super_admin';
+		$sanitize_callback = 'wp_kses_post';
+
+		wp_seo()->register_meta( $meta_key, array(
+			'auth_callback' => $auth_callback,
+			'object_type' => array( $object_type ),
+			'sanitize_callback' => $sanitize_callback,
+		) );
+
+		$this->assertNotFalse( has_filter(
+			"auth_{$object_type}_meta_{$meta_key}",
+			$auth_callback
+		) );
+
+		$this->assertNotFalse( has_filter(
+			"sanitize_{$object_type}_meta_{$meta_key}",
+			$sanitize_callback
+		) );
+	}
+
+	public function test_register_meta_must_register_sanitize_callback() {
+		$meta_key = rand_str();
+		$object_type = 'foo';
+
+		wp_seo()->register_meta( $meta_key, array(
+			'object_type' => $object_type,
+			'sanitize_callback' => false,
+		) );
+
+		$this->assertNotFalse( has_filter(
+			"sanitize_{$object_type}_meta_{$meta_key}",
+			'sanitize_text_field'
+		) );
 	}
 }


### PR DESCRIPTION
I updated `wp_seo_sanitize_integer_field()` a little bit and added a test. Please let me know if I misunderstood what the function was supposed to do.