### PR TITLE
Allow  to always modify the title tag format

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,6 @@ matrix:
     fast_finish: true
 
     include:
-        - php: '5.3'
-          env: WP_VERSION=master PHP_LINT=1
-        - php: '5.3'
-          env: WP_VERSION=4.8
-        - php: '5.3'
-          env: WP_VERSION=4.7
-
         - php: '5.6'
           env: WP_VERSION=master PHP_LINT=1 WP_PHPCS=1
         - php: '5.6'

--- a/php/class-wp-seo.php
+++ b/php/class-wp-seo.php
@@ -460,7 +460,7 @@ if ( ! class_exists( 'WP_SEO' ) ) :
 			/**
 			 * Filter the format string of the title tag for the current page.
 			 *
-			 * @param  string		The format string retrieved from the settings.
+			 * @param  string $title_string The format string retrieved from the settings.
 			 * @param  string $key 	The key of the setting retrieved.
 			 */
 			$title_string = apply_filters( 'wp_seo_title_tag_format', $title_string, $key );

--- a/php/class-wp-seo.php
+++ b/php/class-wp-seo.php
@@ -452,14 +452,21 @@ if ( ! class_exists( 'WP_SEO' ) ) :
 				$key = false;
 			}
 
+			$title_string = null;
 			if ( $key ) {
-				/**
-				 * Filter the format string of the title tag for the current page.
-				 *
-				 * @param  string		The format string retrieved from the settings.
-				 * @param  string $key 	The key of the setting retrieved.
-				 */
-				$title_string = apply_filters( 'wp_seo_title_tag_format', WP_SEO_Settings()->get_option( $key ), $key );
+				$title_string = WP_SEO_Settings()->get_option( $key );
+			}
+
+			/**
+			 * Filter the format string of the title tag for the current page.
+			 *
+			 * @param  string		The format string retrieved from the settings.
+			 * @param  string $key 	The key of the setting retrieved.
+			 */
+			$title_string = apply_filters( 'wp_seo_title_tag_format', $title_string, $key );
+
+			// Format the title string if set.
+			if ( ! empty( $title_string ) ) {
 				$title_tag = $this->format( $title_string );
 				if ( $title_tag && ! is_wp_error( $title_tag ) ) {
 					$title = $title_tag;


### PR DESCRIPTION
Allow the `wp_seo_title_tag_format` to always filter the title tag. Previously, it had to match conditions for it to be met that didn't allow custom archives/rewrites to properly use wp-seo to set the title. Now, it will always allow a filterable tag format even if the conditions aren't met for the title `$key`