### PR TITLE
Fix CAP incompatability

### DIFF
--- a/php/default-formatting-tags.php
+++ b/php/default-formatting-tags.php
@@ -254,7 +254,9 @@ class WP_SEO_Format_Author extends WP_SEO_Formatting_Tag {
 				return apply_filters( 'the_author', get_the_author_meta( 'display_name', $post_author ) );
 			}
 		} elseif ( is_author() ) {
-			return get_the_author_meta( 'display_name', get_queried_object_id() );
+			$author = get_queried_object();
+
+			return $author->display_name;
 		}
 
 		return false;


### PR DESCRIPTION
Currently, the plugin uses `get_the_author_meta()` on author archives, passing the `get_queried_object_id()`. However, on Co-Authors Plus archives, `get_queried_object_id()` returns the `guest-author` post ID, and so `get_the_author_meta()` - which queries the `users` table - retrieves either an empty display name, or the display name of whatever random user happens to have that ID in the database.

This update uses `get_queried_object()`, instead, to retrieve the correct display name.