### PR TITLE
PHP 8: avoid a warning about the usage of the ASP style tag

### DIFF
--- a/php/class-wp-seo-settings.php
+++ b/php/class-wp-seo-settings.php
@@ -652,7 +652,12 @@ class WP_SEO_Settings {
 								?>
 							</div><!-- .wp-seo-repeatable-field -->
 						<?php endforeach; ?>
-						<a href="#" class="wp-seo-delete"><%= wp_seo_admin.repeatable_remove_label %></a>
+						<?php
+							printf(
+								'<a href="#" class="wp-seo-delete">%1$s</a>',
+								'<%= wp_seo_admin.repeatable_remove_label %>'
+							);
+						?>
 					</div><!-- .wp-seo-repeatable-group -->
 				</script>
 			</div><!-- .wp-seo-repeatable -->


### PR DESCRIPTION
Warning:

```
------------------------------------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
------------------------------------------------------------------------------------------------------------------------
 655 | WARNING | Possible use of ASP style opening tags detected. ASP style opening tags have been removed in PHP 7.0.
     |         | Found: <%= wp_seo_admin.repeatable...
------------------------------------------------------------------------------------------------------------------------
```