### PR TITLE
Issue-121: Warnings in `wp_seo_match_all_formatting_tags()` with PHP 8.3

### DIFF
--- a/php/formatting-functions.php
+++ b/php/formatting-functions.php
@@ -17,14 +17,12 @@ function wp_seo_match_all_formatting_tags( $string ) {
 	$formatting_tags = [];
 
 	$pattern = WP_SEO()->formatting_tag_pattern;
-	if ( empty( $pattern ) ) {
-		return $formatting_tags;
-	}
+	if ( ! empty( $pattern ) ) {
+		preg_match_all( $pattern, $string, $matches, PREG_PATTERN_ORDER );
 
-	preg_match_all( WP_SEO()->formatting_tag_pattern, $string, $matches, PREG_PATTERN_ORDER );
-
-	if ( ! empty( $matches[0] ) ) {
-		$formatting_tags = $matches[0];
+		if ( ! empty( $matches[0] ) ) {
+			$formatting_tags = $matches[0];
+		}
 	}
 
 	return $formatting_tags;

--- a/php/formatting-functions.php
+++ b/php/formatting-functions.php
@@ -14,8 +14,20 @@
  * @return array Array with any found formatting tags. Duplicates are retained.
  */
 function wp_seo_match_all_formatting_tags( $string ) {
+	$formatting_tags = [];
+
+	$pattern = WP_SEO()->formatting_tag_pattern;
+	if ( empty( $pattern ) ) {
+		return $formatting_tags;
+	}
+
 	preg_match_all( WP_SEO()->formatting_tag_pattern, $string, $matches, PREG_PATTERN_ORDER );
-	return $matches[0];
+
+	if ( ! empty( $matches[0] ) ) {
+		$formatting_tags = $matches[0];
+	}
+
+	return $formatting_tags;
 }
 
 /**


### PR DESCRIPTION
### Summary

Fixes #121

### Description

This pull request addresses the warnings encountered in the `wp_seo_match_all_formatting_tags()` function when used with PHP 8.3, as reported in the issue. Specifically, it resolves the following warnings:

- `Warning: preg_match_all(): Empty regular expression in wp-content/plugins/wp-seo/php/formatting-functions.php on line 17`
- `Warning: Trying to access array offset on null in wp-content/plugins/wp-seo/php/formatting-functions.php on line 18`

### Changes Made

- Adjusted the `preg_match_all()` call to ensure the regular expression is not empty.
- Added checks to prevent accessing array offsets on null values.

### How to Test

1. Install PHP 8.3
2. Install the plugin
3. Verify that the warnings no longer appear.

### Additional Information

- Relevant issue: [Warnings in `wp_seo_match_all_formatting_tags()` with PHP 8.3](https://github.com/alleyinteractive/wp-seo/issues/121)
