### PR TITLE
Issue 137: Add open graph preview

### DIFF
--- a/entries/open-graph/OpenGraphSlotfill.tsx
+++ b/entries/open-graph/OpenGraphSlotfill.tsx
@@ -1,4 +1,5 @@
-import { TextareaControl, TextControl } from '@wordpress/components';
+import { useState } from 'react';
+import { Button, TextareaControl, TextControl } from '@wordpress/components';
 import { PluginDocumentSettingPanel } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
 
@@ -6,11 +7,23 @@ import {
   ImagePicker,
   usePostMetaValue,
 } from '@alleyinteractive/block-editor-tools';
+import PreviewModal from './PreviewModal';
+
+import './style.scss';
 
 function OpenGraphSlotfill() {
   const [title, setTitle] = usePostMetaValue('wp_seo_open_graph_title');
   const [description, setDescription] = usePostMetaValue('wp_seo_open_graph_description');
   const [image, setImage] = usePostMetaValue('wp_seo_open_graph_image');
+  const [showModal, setShowModal] = useState(false);
+
+  const openModal = () => {
+    setShowModal(true);
+  };
+
+  const closeModal = () => {
+    setShowModal(false);
+  };
 
   return (
     <PluginDocumentSettingPanel
@@ -38,6 +51,21 @@ function OpenGraphSlotfill() {
         onUpdate={({ id: next }) => setImage(next)}
         value={image}
       />
+      <br />
+      <Button
+        onClick={openModal}
+        variant="secondary"
+      >
+        Preview
+      </Button>
+      {showModal ? (
+        <PreviewModal
+          onClose={closeModal}
+          openGraphTitle={title}
+          openGraphDescription={description}
+          openGraphImageId={image}
+        />
+      ) : null}
     </PluginDocumentSettingPanel>
   );
 }

--- a/entries/open-graph/OpenGraphSlotfill.tsx
+++ b/entries/open-graph/OpenGraphSlotfill.tsx
@@ -56,7 +56,7 @@ function OpenGraphSlotfill() {
         onClick={openModal}
         variant="secondary"
       >
-        Preview
+        {__('Preview', 'wp-seo')}
       </Button>
       {showModal ? (
         <PreviewModal

--- a/entries/open-graph/PreviewModal.tsx
+++ b/entries/open-graph/PreviewModal.tsx
@@ -1,0 +1,92 @@
+import { __ } from '@wordpress/i18n';
+import { select } from '@wordpress/data';
+import { Modal, TabPanel } from '@wordpress/components';
+import SocialPreview from './SocialPreview';
+import SearchPreview from './SearchPreview';
+
+interface PreviewModalProps {
+  onClose: () => void;
+  openGraphTitle: string;
+  openGraphDescription: string;
+  openGraphImageId: number;
+}
+
+function PreviewModal({
+  onClose,
+  openGraphTitle,
+  openGraphDescription,
+  openGraphImageId,
+}: PreviewModalProps) {
+  const postType = select('core/editor').getCurrentPostType();
+  const postTitle = select('core/editor').getEditedPostAttribute('title');
+  const postLink = select('core/editor').getEditedPostAttribute('link');
+  const postModified = select('core/editor').getEditedPostAttribute('modified');
+  const postExcerpt = select('core/editor').getEditedPostAttribute('excerpt');
+  const featuredImageId = select('core/editor').getEditedPostAttribute('featured_media');
+  const siteData = select('core').getEditedEntityRecord('root', 'site');
+
+  // Use open graph title, fall back to current post title
+  const previewTitle = openGraphTitle || postTitle;
+  // If title is longer than 60 characters, truncate
+  const searchTitle = previewTitle.length > 60 ? `${previewTitle.substring(0, 60).trim()}…` : previewTitle;
+
+  // Use open graph description, fall back to custom excerpt or auto-generated excerpt
+  const previewDescription = openGraphDescription || postExcerpt.replace(/<\/?[^>]+(>|$)/g, '');
+  // If description is longer than 160 characters, truncate
+  const searchDescription = previewDescription.length > 160 ? `${previewDescription.substring(0, 160).trim()}…` : previewDescription;
+
+  // Use open graph image, fall back to featured image
+  const previewImageId = openGraphImageId || featuredImageId;
+
+  const siteTitle = siteData.title;
+  // Remove prototcol from site URL
+  const siteUrl = siteData.url.replace(/(^\w+:|^)\/\//, '');
+  const siteIcon = siteData.site_icon;
+  // If the site has no timezone set, use the browser's current timezone
+  const siteTimezone = siteData.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+  return (
+    <Modal
+      onRequestClose={onClose}
+      className="open-graph-preview"
+      title={__('Open Graph Preview', 'wp-seo')}
+    >
+      <TabPanel
+        onSelect={() => { }}
+        tabs={[
+          {
+            name: 'search',
+            title: 'Search',
+            content: <SearchPreview
+              title={searchTitle}
+              description={searchDescription}
+              imageId={previewImageId}
+              link={postLink}
+              date={postModified}
+              postType={postType}
+              siteIcon={siteIcon}
+              siteTitle={siteTitle}
+              siteTimezone={siteTimezone}
+            />,
+          },
+          {
+            name: 'social',
+            title: 'Social',
+            content: <SocialPreview
+              title={previewTitle}
+              description={previewDescription}
+              imageId={previewImageId}
+              siteUrl={siteUrl}
+            />,
+          },
+        ]}
+      >
+        {({ content }) => (
+          content
+        )}
+      </TabPanel>
+    </Modal>
+  );
+}
+
+export default PreviewModal;

--- a/entries/open-graph/SearchPreview.tsx
+++ b/entries/open-graph/SearchPreview.tsx
@@ -4,7 +4,7 @@ import { useMedia } from '@alleyinteractive/block-editor-tools';
 interface SearchPreviewProps {
   title: string;
   description: string;
-  imageId: number;
+  imageId?: number;
   date: string;
   link: string;
   postType: string;

--- a/entries/open-graph/SearchPreview.tsx
+++ b/entries/open-graph/SearchPreview.tsx
@@ -1,0 +1,70 @@
+import { date as wpDate } from '@wordpress/date';
+import { useMedia } from '@alleyinteractive/block-editor-tools';
+
+interface SearchPreviewProps {
+  title: string;
+  description: string;
+  imageId: number;
+  date: string;
+  link: string;
+  postType: string;
+  siteTitle: string;
+  siteIcon: string;
+  siteTimezone: string;
+}
+
+function SearchPreview({
+  title,
+  description,
+  imageId,
+  date,
+  link,
+  postType,
+  siteTitle,
+  siteIcon,
+  siteTimezone,
+}: SearchPreviewProps) {
+  const icon = useMedia(siteIcon);
+  const searchImage = useMedia(imageId);
+
+  const previewDate = postType === 'post' ? (
+    <span className="search-preview-date">{wpDate('F j, Y', date, siteTimezone)}</span>
+  ) : null;
+
+  return (
+    <div className="wp-seo-search-preview">
+      <div className="search-preview-container">
+        <div className="search-preview-header">
+          {icon ? (
+            <div className="search-preview-icon">
+              <img src={icon?.media_details?.sizes?.thumbnail?.source_url} alt="" />
+            </div>
+          ) : null}
+          <div className="search-preview-site">
+            <p>{siteTitle}</p>
+            <p>{link}</p>
+          </div>
+        </div>
+
+        <div className="search-preview-text">
+          <h2>{title}</h2>
+          <p>
+            {previewDate}
+            {previewDate && description ? (
+              <span> &mdash; </span>
+            ) : null}
+            {description}
+          </p>
+        </div>
+      </div>
+
+      {searchImage ? (
+        <div className="search-preview-image">
+          <img src={searchImage?.media_details?.sizes?.medium?.source_url} alt="" />
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export default SearchPreview;

--- a/entries/open-graph/SearchPreview.tsx
+++ b/entries/open-graph/SearchPreview.tsx
@@ -9,7 +9,7 @@ interface SearchPreviewProps {
   link: string;
   postType: string;
   siteTitle: string;
-  siteIcon: string;
+  siteIcon?: string;
   siteTimezone: string;
 }
 

--- a/entries/open-graph/SocialPreview.tsx
+++ b/entries/open-graph/SocialPreview.tsx
@@ -1,0 +1,35 @@
+import { useMedia } from '@alleyinteractive/block-editor-tools';
+
+interface SocialPreviewProps {
+  title: string;
+  description: string;
+  imageId: number;
+  siteUrl: string;
+}
+
+function SocialPreview({
+  title,
+  description,
+  imageId,
+  siteUrl,
+}: SocialPreviewProps) {
+  const socialImage = useMedia(imageId);
+
+  return (
+    <div className="wp-seo-social-preview">
+      <div className="social-preview-container">
+        {socialImage ? (
+          <img src={socialImage.media_details?.sizes?.large?.source_url} alt="" />
+        ) : null}
+
+        <div className="social-preview-text">
+          <p className="social-preview-url">{siteUrl}</p>
+          <h2>{title}</h2>
+          <p>{description}</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default SocialPreview;

--- a/entries/open-graph/SocialPreview.tsx
+++ b/entries/open-graph/SocialPreview.tsx
@@ -3,7 +3,7 @@ import { useMedia } from '@alleyinteractive/block-editor-tools';
 interface SocialPreviewProps {
   title: string;
   description: string;
-  imageId: number;
+  imageId?: number;
   siteUrl: string;
 }
 

--- a/entries/open-graph/index.php
+++ b/entries/open-graph/index.php
@@ -31,3 +31,11 @@ function wp_seo_register_open_graph_scripts() {
 	wp_set_script_translations( 'wp-seo-open-graph-js', 'wp-seo' );
 }
 add_action( 'init', 'wp_seo_register_open_graph_scripts' );
+
+/**
+ * Enqueue open graph slotfill styles.
+ */
+function wp_seo_register_open_graph_styles() {
+	wp_enqueue_style( 'wp-seo-open-graph', plugins_url( '../style-open-graph/index.css', __FILE__ ), [], '1.0.0' );
+}
+add_action( 'enqueue_block_editor_assets', 'wp_seo_register_open_graph_styles' );

--- a/entries/open-graph/style.scss
+++ b/entries/open-graph/style.scss
@@ -1,10 +1,4 @@
 .open-graph-preview {
-
-  // Remove before committing
-  .components-modal__content {
-    width: auto;
-  }
-
   .wp-seo-search-preview,
   .wp-seo-social-preview {
     background-color: #efefef;

--- a/entries/open-graph/style.scss
+++ b/entries/open-graph/style.scss
@@ -1,0 +1,118 @@
+.open-graph-preview {
+
+  // Remove before committing
+  .components-modal__content {
+    width: auto;
+  }
+
+  .wp-seo-search-preview,
+  .wp-seo-social-preview {
+    background-color: #efefef;
+    border-radius: 0 0 0.3125rem 0.3125rem;
+    padding: 2rem;
+    width: 100%;
+
+    @media (min-width: 782px) {
+      width: 40rem;
+    }
+
+    h2 {
+      line-height: 1.3;
+    }
+
+    p {
+      line-height: 1.5;
+      margin: 0;
+    }
+  }
+
+  .wp-seo-search-preview {
+    display: flex;
+    column-gap: 1.25rem;
+    font-family: Arial, sans-serif;
+
+    .search-preview-container {
+      flex-grow: 1;
+    }
+
+    .search-preview-header {
+      align-items: center;
+      display: flex;
+      column-gap: 0.5rem;
+      margin-bottom: 0.3125rem;
+
+      p {
+        color: #333;
+      }
+    }
+
+    .search-preview-icon {
+      width: 1.625rem;
+      height: 1.625rem;
+
+      img {
+        border-radius: 50%;
+        height: 100%;
+        object-fit: cover;
+        width: 100%;
+      }
+    }
+
+    h2 {
+      color: #4007a2;
+      font-size: 1.25rem;
+      font-weight: normal;
+      margin: 0 0 0.1875rem;
+    }
+
+    p {
+      color: #4d5156;
+      font-size: 0.875rem;
+    }
+
+    .search-preview-date {
+      color: #666a6f;
+    }
+
+    .search-preview-image {
+      img {
+        border-radius: 0.5rem;
+        height: 5.625rem;
+        object-fit: cover;
+        width: 5.625rem;
+      }
+    }
+  }
+
+  .wp-seo-social-preview {
+    .social-preview-container {
+      border: 1px solid #d3d3d3;
+      background-color: #fff;
+      border-radius: 1rem;
+      margin: 0 auto;
+      max-width: 32rem;
+      overflow: hidden;
+
+      img {
+        aspect-ratio: 16 / 9;
+        display: block;
+        height: auto;
+        object-fit: cover;
+        width: 100%;
+      }
+    }
+
+    .social-preview-text {
+      padding: 1rem 1.25rem;
+    }
+
+    .social-preview-url {
+      margin-bottom: 0.1875rem;
+    }
+
+    h2 {
+      font-size: 1rem;
+      margin: 0 0 0.3125rem;
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@wordpress/blocks": "^13.8.5",
         "@wordpress/components": "^28.8.11",
         "@wordpress/data": "^10.8.3",
+        "@wordpress/date": "^5.19.0",
         "@wordpress/edit-post": "^8.8.18",
         "@wordpress/editor": "^14.18.0",
         "@wordpress/i18n": "^5.8.2",
@@ -7172,12 +7173,13 @@
       }
     },
     "node_modules/@wordpress/date": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.18.0.tgz",
-      "integrity": "sha512-x5k5pobYHq83BydLnHBOaMwuhqRafRYAgAs0aq5F08C5s33qg7JEKCJbiYZbAH/d9MeDrfAQwlFE9oj5Fx8yew==",
+      "version": "5.19.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.19.0.tgz",
+      "integrity": "sha512-EZ31S8za/SRpUhgLSbKePaWIFuuLy5YzU0k9pdbxw3bc6qjC8Yfl72Envw0oMqgBbylYNGJa+hfeNEBWzDBKMA==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/runtime": "7.25.7",
-        "@wordpress/deprecated": "^4.18.0",
+        "@wordpress/deprecated": "^4.19.0",
         "moment": "^2.29.4",
         "moment-timezone": "^0.5.40"
       },
@@ -7211,12 +7213,13 @@
       "license": "BSD"
     },
     "node_modules/@wordpress/deprecated": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.18.0.tgz",
-      "integrity": "sha512-GtTmirQsz4NmSLOyLGL6MmWBM41M0lAet2nWhkf8gmyoO2n7bc7UpyqxiyijW7R6N2imvvJyD5ZMqLRBBVk/IQ==",
+      "version": "4.19.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.19.0.tgz",
+      "integrity": "sha512-PlOodANvm8IfznNwPv+gLV83wLSV1MDnkQ+An3NIod0uEgapqRztqpuMCLZIsk/uHyrPas3eg7aNyjOk3tHT7Q==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/runtime": "7.25.7",
-        "@wordpress/hooks": "^4.18.0"
+        "@wordpress/hooks": "^4.19.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -7868,9 +7871,10 @@
       }
     },
     "node_modules/@wordpress/hooks": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.18.0.tgz",
-      "integrity": "sha512-hJulGAT2ELS+UBCTPnTe2A2ep+sOF4PO/x41UmeSgiaIJV1G4xNCJnlcyuCsV3xI2CTnf+YqjyS3qbqhLq3YOA==",
+      "version": "4.19.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.19.0.tgz",
+      "integrity": "sha512-fIISVBC8XtZEtltYYm1yCgJiBw3TkDI5hXuIyTaJAlOWwcjj7geyjghd0lsIbr5CerTrh9/rPG121M+uvHK5NQ==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/runtime": "7.25.7"
       },
@@ -31158,12 +31162,12 @@
       }
     },
     "@wordpress/date": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.18.0.tgz",
-      "integrity": "sha512-x5k5pobYHq83BydLnHBOaMwuhqRafRYAgAs0aq5F08C5s33qg7JEKCJbiYZbAH/d9MeDrfAQwlFE9oj5Fx8yew==",
+      "version": "5.19.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.19.0.tgz",
+      "integrity": "sha512-EZ31S8za/SRpUhgLSbKePaWIFuuLy5YzU0k9pdbxw3bc6qjC8Yfl72Envw0oMqgBbylYNGJa+hfeNEBWzDBKMA==",
       "requires": {
         "@babel/runtime": "7.25.7",
-        "@wordpress/deprecated": "^4.18.0",
+        "@wordpress/deprecated": "^4.19.0",
         "moment": "^2.29.4",
         "moment-timezone": "^0.5.40"
       }
@@ -31186,12 +31190,12 @@
       }
     },
     "@wordpress/deprecated": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.18.0.tgz",
-      "integrity": "sha512-GtTmirQsz4NmSLOyLGL6MmWBM41M0lAet2nWhkf8gmyoO2n7bc7UpyqxiyijW7R6N2imvvJyD5ZMqLRBBVk/IQ==",
+      "version": "4.19.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.19.0.tgz",
+      "integrity": "sha512-PlOodANvm8IfznNwPv+gLV83wLSV1MDnkQ+An3NIod0uEgapqRztqpuMCLZIsk/uHyrPas3eg7aNyjOk3tHT7Q==",
       "requires": {
         "@babel/runtime": "7.25.7",
-        "@wordpress/hooks": "^4.18.0"
+        "@wordpress/hooks": "^4.19.0"
       }
     },
     "@wordpress/dom": {
@@ -31707,9 +31711,9 @@
       }
     },
     "@wordpress/hooks": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.18.0.tgz",
-      "integrity": "sha512-hJulGAT2ELS+UBCTPnTe2A2ep+sOF4PO/x41UmeSgiaIJV1G4xNCJnlcyuCsV3xI2CTnf+YqjyS3qbqhLq3YOA==",
+      "version": "4.19.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.19.0.tgz",
+      "integrity": "sha512-fIISVBC8XtZEtltYYm1yCgJiBw3TkDI5hXuIyTaJAlOWwcjj7geyjghd0lsIbr5CerTrh9/rPG121M+uvHK5NQ==",
       "requires": {
         "@babel/runtime": "7.25.7"
       }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@wordpress/blocks": "^13.8.5",
     "@wordpress/components": "^28.8.11",
     "@wordpress/data": "^10.8.3",
+    "@wordpress/date": "^5.19.0",
     "@wordpress/edit-post": "^8.8.18",
     "@wordpress/editor": "^14.18.0",
     "@wordpress/i18n": "^5.8.2",


### PR DESCRIPTION
Adds a preview modal to the new open graph panel in the editor sidebar. Displays the search preview by default, and allows the user to switch to a social preview. Uses the open graph data by default, and falls back to the post data.