### PR TITLE
Issue-167: Make it possible to add values to robots.txt via the admin

### DIFF
--- a/php/class-wp-seo-settings.php
+++ b/php/class-wp-seo-settings.php
@@ -860,19 +860,6 @@ class WP_SEO_Settings {
 	/**
 	 * Render a section's fields as a meta box.
 	 *
-	 * @param  mixed $object Unused. Data passed from do_accordion_sections().
-	 * @param  array $box {
-	 *     An array of meta box arguments.
-	 *
-	 *     @type  string $id @see add_meta_box().
-	 *     @type  string $title @see add_meta_box().
-	 *     @type  callback $callback @see add_meta_box().
-	 *     @type  array $args @see add_meta_box(), add_settings_section().
-	 * }
-	 */
-	/**
-	 * Render a section's fields as a meta box.
-	 *
 	 * @param mixed $_object Unused. Data passed from do_accordion_sections().
 	 * @param array $box {
 	 *     An array of meta box arguments.

--- a/php/class-wp-seo-settings.php
+++ b/php/class-wp-seo-settings.php
@@ -334,7 +334,6 @@ class WP_SEO_Settings {
 		add_settings_field( 'robots_example', __( 'Robots.txt Example', 'wp-seo' ), array( $this, 'example_robots_txt' ), $this::SLUG, 'robots' );
 		add_settings_field( 'robots_txt_prefix', __( 'Add to start of Robots.txt', 'wp-seo' ), array( $this, 'field' ), $this::SLUG, 'robots', array( 'type' => 'textarea', 'field' => 'robots_txt_prefix' ) );
 		add_settings_field( 'robots_txt_suffix', __( 'Add to end of Robots.txt', 'wp-seo' ), array( $this, 'field' ), $this::SLUG, 'robots', array( 'type' => 'textarea', 'field' => 'robots_txt_suffix' ) );
-
 	}
 
 	/**

--- a/php/class-wp-seo-settings.php
+++ b/php/class-wp-seo-settings.php
@@ -38,6 +38,13 @@ class WP_SEO_Settings {
 	public $options = array();
 
 	/**
+	 * Storage unit for the current network option values of the plugin.
+	 *
+	 * @var array.
+	 */
+	public $network_options = array();
+
+	/**
 	 * Taxonomies with archive pages, which can have meta fields set for them.
 	 *
 	 * @see  WP_SEO_Settings::setup().
@@ -65,6 +72,8 @@ class WP_SEO_Settings {
 	private $archived_post_types = array();
 
 	const SLUG = 'wp-seo';
+
+	const NETWORK_SLUG = 'wp-seo-network';
 
 	/**
 	 * Unused.
@@ -118,6 +127,8 @@ class WP_SEO_Settings {
 			add_action( 'admin_menu', array( $this, 'add_options_page' ) );
 			add_action( 'admin_init', array( $this, 'register_settings' ) );
 			add_action( 'load-settings_page_' . $this::SLUG, array( $this, 'add_help_tab' ) );
+			add_action( 'network_admin_menu', array( $this, 'add_network_options_page' ) );
+			add_action( 'network_admin_edit_wp-seo-network', array( $this, 'save_network_settings' ) );
 		}
 	}
 
@@ -183,6 +194,27 @@ class WP_SEO_Settings {
 			$this->set_options();
 		}
 		return isset( $this->options[ $key ] ) ? $this->options[ $key ] : $default;
+	}
+
+	/**
+	 * Set $network_options with the current network database value.
+	 */
+	public function set_network_options() {
+		$this->network_options = get_site_option( $this::NETWORK_SLUG, array() );
+	}
+
+	/**
+	 * Get a network option value.
+	 *
+	 * @param string $key     The option key sought.
+	 * @param mixed  $default Optional default.
+	 * @return mixed The value, or null on failure.
+	 */
+	public function get_network_option( $key, $default = null ) {
+		if ( empty( $this->network_options ) ) {
+			$this->set_network_options();
+		}
+		return isset( $this->network_options[ $key ] ) ? $this->network_options[ $key ] : $default;
 	}
 
 	/**
@@ -255,6 +287,75 @@ class WP_SEO_Settings {
 	 */
 	public function add_options_page() {
 		add_options_page( __( 'WP SEO Settings', 'wp-seo' ), __( 'SEO', 'wp-seo' ), $this->options_capability, $this::SLUG, array( $this, 'view_settings_page' ) );
+	}
+
+	/**
+	 * Register the plugin network options page.
+	 */
+	public function add_network_options_page() {
+		add_submenu_page( 'settings.php', __( 'WP SEO Settings', 'wp-seo' ), __( 'SEO', 'wp-seo' ), 'manage_network_options', $this::SLUG, array( $this, 'view_network_settings_page' ) );
+	}
+
+	/**
+	 * Render the network settings page for robots.txt network prefix/suffix fields.
+	 */
+	public function view_network_settings_page() {
+		$prefix = $this->get_network_option( 'robots_txt_network_prefix', '' );
+		$suffix = $this->get_network_option( 'robots_txt_network_suffix', '' );
+		?>
+		<div class="wrap" id="wp_seo_network_settings">
+			<h2><?php esc_html_e( 'WP SEO Network Settings', 'wp-seo' ); ?></h2>
+			<?php if ( filter_input( INPUT_GET, 'updated' ) ) : ?>
+				<div class="notice notice-success is-dismissible"><p><?php esc_html_e( 'Settings saved.', 'wp-seo' ); ?></p></div>
+			<?php endif; ?>
+			<form action="edit.php?action=wp-seo-network" method="POST">
+				<?php wp_nonce_field( 'wp-seo-network-options' ); ?>
+				<h3><?php esc_html_e( 'Robots.txt', 'wp-seo' ); ?></h3>
+				<table class="form-table">
+					<tr>
+						<th scope="row"><?php esc_html_e( 'Add to start of Robots.txt (Network)', 'wp-seo' ); ?></th>
+						<td><?php $this->render_textarea( array( 'field' => 'robots_txt_network_prefix' ), $prefix ); ?></td>
+					</tr>
+					<tr>
+						<th scope="row"><?php esc_html_e( 'Add to end of Robots.txt (Network)', 'wp-seo' ); ?></th>
+						<td><?php $this->render_textarea( array( 'field' => 'robots_txt_network_suffix' ), $suffix ); ?></td>
+					</tr>
+				</table>
+				<?php submit_button(); ?>
+			</form>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Handle saving the network robots.txt settings.
+	 *
+	 * Double-gated: only processes when the request originates from the network
+	 * admin (via the network_admin_edit_wp-seo-network action) and the current
+	 * user has manage_network_options. This prevents network settings from being
+	 * updated via the regular per-site settings form, even by users who hold
+	 * network admin credentials.
+	 */
+	public function save_network_settings() {
+		check_admin_referer( 'wp-seo-network-options' );
+
+		if ( ! is_network_admin() || ! current_user_can( 'manage_network_options' ) ) {
+			wp_die( esc_html__( 'You do not have permission to perform this action.', 'wp-seo' ) );
+		}
+
+		$in = isset( $_POST[ $this::SLUG ] ) && is_array( $_POST[ $this::SLUG ] ) ? $_POST[ $this::SLUG ] : array();
+
+		if ( empty( $this->network_options ) ) {
+			$this->set_network_options();
+		}
+
+		$this->network_options['robots_txt_network_prefix'] = isset( $in['robots_txt_network_prefix'] ) && is_string( $in['robots_txt_network_prefix'] ) ? sanitize_text_field( $in['robots_txt_network_prefix'] ) : '';
+		$this->network_options['robots_txt_network_suffix'] = isset( $in['robots_txt_network_suffix'] ) && is_string( $in['robots_txt_network_suffix'] ) ? sanitize_text_field( $in['robots_txt_network_suffix'] ) : '';
+
+		update_site_option( $this::NETWORK_SLUG, $this->network_options );
+
+		wp_safe_redirect( add_query_arg( array( 'page' => $this::SLUG, 'updated' => 'true' ), network_admin_url( 'settings.php' ) ) );
+		exit;
 	}
 
 	/**

--- a/php/class-wp-seo-settings.php
+++ b/php/class-wp-seo-settings.php
@@ -844,9 +844,9 @@ class WP_SEO_Settings {
 					if ( apply_filters( 'wp_seo_use_settings_accordions', true ) ) {
 						global $wp_settings_sections;
 						foreach ( (array) $wp_settings_sections[ $this::SLUG ] as $section ) {
-							add_meta_box( $section['id'], $section['title'], array( $this, 'settings_meta_box' ), 'wp-seo', 'advanced', 'default', array_merge( $section, array( 'slug' => $this::SLUG ) ) );
+							add_meta_box( $section['id'], $section['title'], array( $this, 'settings_meta_box' ), $this::SLUG, 'advanced', 'default', array_merge( $section, array( 'slug' => $this::SLUG ) ) );
 						}
-						do_accordion_sections( 'wp-seo', 'advanced', null );
+						do_accordion_sections( $this::SLUG, 'advanced', null );
 					} else {
 						do_settings_sections( $this::SLUG );
 					}

--- a/php/class-wp-seo-settings.php
+++ b/php/class-wp-seo-settings.php
@@ -328,6 +328,11 @@ class WP_SEO_Settings {
 
 		add_settings_section( 'arbitrary', __( 'Other Meta Tags', 'wp-seo' ), false, $this::SLUG );
 		add_settings_field( 'arbitrary_tags', __( 'Tags', 'wp-seo' ), array( $this, 'field' ), $this::SLUG, 'arbitrary', array( 'type' => 'repeatable', 'field' => 'arbitrary_tags', 'repeat' => array( 'name' => __( 'Name', 'lin' ), 'content' => __( 'Content', 'lin' ) ) ) );
+
+		add_settings_section( 'robots', __( 'Robots.txt', 'wp-seo' ), false, $this::SLUG );
+		add_settings_field( 'robots_example', __( 'Robots.txt Example', 'wp-seo' ), array( $this, 'example_robots_txt' ), $this::SLUG, 'robots' );
+		add_settings_field( 'robots_txt_prefix', __( 'Add to start of Robots.txt', 'wp-seo' ), array( $this, 'field' ), $this::SLUG, 'robots', array( 'type' => 'textarea', 'field' => 'robots_txt_prefix' ) );
+		add_settings_field( 'robots_txt_suffix', __( 'Add to end of Robots.txt', 'wp-seo' ), array( $this, 'field' ), $this::SLUG, 'robots', array( 'type' => 'textarea', 'field' => 'robots_txt_suffix' ) );
 	}
 
 	/**
@@ -356,6 +361,16 @@ class WP_SEO_Settings {
 			echo ' <code><a href="' . esc_url( $url ) . '" target="_blank">' . esc_html( $url ) . '</a></code>';
 		}
 		echo '</p>';
+	}
+
+	/**
+	 * Display the compiled Robots.txt contents in an uneditable field.
+	 */
+	public function example_robots_txt() {
+		ob_start();
+		@do_robots();
+		$robots = ob_get_clean();
+		$this->render_textarea([ 'field' => 'robots_txt', 'disabled' => true ], $robots );
 	}
 
 	/**
@@ -524,11 +539,12 @@ class WP_SEO_Settings {
 		) );
 
 		printf(
-			'<textarea name="%s[%s]" rows="%d" cols="%d">%s</textarea>',
+			'<textarea name="%s[%s]" rows="%d" cols="%d"%s>%s</textarea>',
 			esc_attr( $this::SLUG ),
 			esc_attr( $args['field'] ),
 			esc_attr( $args['rows'] ),
 			esc_attr( $args['cols'] ),
+			( ! empty( $args['disabled'] ) ? ' disabled' : '' ),
 			esc_textarea( $value )
 		);
 	}
@@ -759,6 +775,10 @@ class WP_SEO_Settings {
 		// "Other Pages" titles.
 		$sanitize_as_text_field[] = 'search_title';
 		$sanitize_as_text_field[] = '404_title';
+
+		// Robots.txt fields.
+		$sanitize_as_text_field[] = 'robots_txt_prefix';
+		$sanitize_as_text_field[] = 'robots_txt_suffix';
 
 		foreach ( $sanitize_as_text_field as $field ) {
 			$out[ $field ] = isset( $in[ $field ] ) && is_string( $in[ $field ] ) ? sanitize_text_field( $in[ $field ] ) : null;

--- a/php/class-wp-seo-settings.php
+++ b/php/class-wp-seo-settings.php
@@ -300,27 +300,26 @@ class WP_SEO_Settings {
 	 * Render the network settings page for robots.txt network prefix/suffix fields.
 	 */
 	public function view_network_settings_page() {
-		$prefix = $this->get_network_option( 'robots_txt_network_prefix', '' );
-		$suffix = $this->get_network_option( 'robots_txt_network_suffix', '' );
 		?>
 		<div class="wrap" id="wp_seo_network_settings">
 			<h2><?php esc_html_e( 'WP SEO Network Settings', 'wp-seo' ); ?></h2>
 			<?php if ( filter_input( INPUT_GET, 'updated' ) ) : ?>
-				<div class="notice notice-success is-dismissible"><p><?php esc_html_e( 'Settings saved.', 'wp-seo' ); ?></p></div>
+				<div class="notice notice-success is-dismissible"><p><?php esc_html_e( 'Network settings saved.', 'wp-seo' ); ?></p></div>
 			<?php endif; ?>
 			<form action="edit.php?action=wp-seo-network" method="POST">
 				<?php wp_nonce_field( 'wp-seo-network-options' ); ?>
-				<h3><?php esc_html_e( 'Robots.txt', 'wp-seo' ); ?></h3>
-				<table class="form-table">
-					<tr>
-						<th scope="row"><?php esc_html_e( 'Add to start of Robots.txt (Network)', 'wp-seo' ); ?></th>
-						<td><?php $this->render_textarea( array( 'field' => 'robots_txt_network_prefix' ), $prefix ); ?></td>
-					</tr>
-					<tr>
-						<th scope="row"><?php esc_html_e( 'Add to end of Robots.txt (Network)', 'wp-seo' ); ?></th>
-						<td><?php $this->render_textarea( array( 'field' => 'robots_txt_network_suffix' ), $suffix ); ?></td>
-					</tr>
-				</table>
+				<?php
+				/** This filter is documented in php/class-wp-seo-settings.php */
+				if ( apply_filters( 'wp_seo_use_settings_accordions', true ) ) {
+					global $wp_settings_sections;
+					foreach ( (array) $wp_settings_sections[ $this::NETWORK_SLUG ] as $section ) {
+						add_meta_box( $section['id'], $section['title'], array( $this, 'network_settings_meta_box' ), $this::NETWORK_SLUG, 'advanced', 'default', $section );
+					}
+					do_accordion_sections( $this::NETWORK_SLUG, 'advanced', null );
+				} else {
+					do_settings_sections( $this::NETWORK_SLUG );
+				}
+				?>
 				<?php submit_button(); ?>
 			</form>
 		</div>
@@ -434,6 +433,13 @@ class WP_SEO_Settings {
 		add_settings_field( 'robots_example', __( 'Robots.txt Example', 'wp-seo' ), array( $this, 'example_robots_txt' ), $this::SLUG, 'robots' );
 		add_settings_field( 'robots_txt_prefix', __( 'Add to start of Robots.txt', 'wp-seo' ), array( $this, 'field' ), $this::SLUG, 'robots', array( 'type' => 'textarea', 'field' => 'robots_txt_prefix' ) );
 		add_settings_field( 'robots_txt_suffix', __( 'Add to end of Robots.txt', 'wp-seo' ), array( $this, 'field' ), $this::SLUG, 'robots', array( 'type' => 'textarea', 'field' => 'robots_txt_suffix' ) );
+
+		if ( is_network_admin() ) {
+			add_settings_section( 'robots', __( 'Robots.txt', 'wp-seo' ), false, $this::NETWORK_SLUG );
+			add_settings_field( 'robots_example', __( 'Robots.txt Example', 'wp-seo' ), array( $this, 'example_robots_txt' ), $this::NETWORK_SLUG, 'robots' );
+			add_settings_field( 'robots_txt_network_prefix', __( 'Add to start of Robots.txt (Network)', 'wp-seo' ), array( $this, 'field_network' ), $this::NETWORK_SLUG, 'robots', array( 'type' => 'textarea', 'field' => 'robots_txt_network_prefix' ) );
+			add_settings_field( 'robots_txt_network_suffix', __( 'Add to end of Robots.txt (Network)', 'wp-seo' ), array( $this, 'field_network' ), $this::NETWORK_SLUG, 'robots', array( 'type' => 'textarea', 'field' => 'robots_txt_network_suffix' ) );
+		}
 	}
 
 	/**
@@ -469,9 +475,20 @@ class WP_SEO_Settings {
 	 */
 	public function example_robots_txt() {
 		ob_start();
+		/* Error suppression is used here because `do_robots` calls `header` which
+		 * throws a warning due to headers already having been sent. There is no
+		 * way around this, without recreating the function and maintaining our
+		 * own version of it entirely. At least as of WordPress 6.9.4.
+		 */
 		@do_robots();
 		$robots = ob_get_clean();
-		$this->render_textarea([ 'field' => 'robots_txt', 'disabled' => true ], $robots );
+		$this->render_textarea([
+				'field'    => 'robots_txt',
+				'disabled' => true,
+				'rows'     => 10,
+			],
+			$robots
+		);
 	}
 
 	/**
@@ -564,6 +581,34 @@ class WP_SEO_Settings {
 	 * }
 	 */
 	public function field( $args ) {
+		$this->render_field( $args, array( $this, 'get_option' ) );
+	}
+
+	/**
+	 * Display a network settings field.
+	 *
+	 * @param array $args Field arguments. @see render_field().
+	 */
+	public function field_network( $args ) {
+		$this->render_field( $args, array( $this, 'get_network_option' ) );
+	}
+
+	/**
+	 * Render a settings field using the provided getter callable.
+	 *
+	 * Shared implementation for field() and field_network(). Callers pass the
+	 * appropriate getter (get_option or get_network_option) so lazy-loading and
+	 * value lookup are handled by the getter regardless of storage source.
+	 *
+	 * @param array    $args   {
+	 *     Field arguments.
+	 *
+	 *     @type string $field The option key to pass to $getter.
+	 *     @type string $type  Optional field type. Defaults to 'text'.
+	 * }
+	 * @param callable $getter Callable that accepts ( $key, $default ) and returns the value.
+	 */
+	protected function render_field( $args, callable $getter ) {
 		if ( empty( $args['field'] ) ) {
 			return;
 		}
@@ -572,7 +617,7 @@ class WP_SEO_Settings {
 			$args['type'] = 'text';
 		}
 
-		$value = ! empty( $this->options[ $args['field'] ] ) ? $this->options[ $args['field'] ] : '';
+		$value = call_user_func( $getter, $args['field'], '' );
 
 		switch ( $args['type'] ) {
 			case 'textarea' :
@@ -832,6 +877,25 @@ class WP_SEO_Settings {
 
 		echo '<table class="form-table">';
 		do_settings_fields( $this::SLUG, $box['args']['id'] );
+		echo '</table>';
+	}
+
+	/**
+	 * Render a network settings section's fields as a meta box.
+	 *
+	 * Mirrors settings_meta_box(), but uses NETWORK_SLUG so do_settings_fields()
+	 * pulls from the network-registered fields rather than the site fields.
+	 *
+	 * @param mixed $object Unused.
+	 * @param array $box    @see settings_meta_box().
+	 */
+	public function network_settings_meta_box( $_object, $box ) {
+		if ( is_callable( $box['args']['callback'] ) ) {
+			call_user_func( $box['args']['callback'], $box['args'] );
+		}
+
+		echo '<table class="form-table">';
+		do_settings_fields( $this::NETWORK_SLUG, $box['args']['id'] );
 		echo '</table>';
 	}
 

--- a/php/class-wp-seo-settings.php
+++ b/php/class-wp-seo-settings.php
@@ -38,13 +38,6 @@ class WP_SEO_Settings {
 	public $options = array();
 
 	/**
-	 * Storage unit for the current network option values of the plugin.
-	 *
-	 * @var array.
-	 */
-	public $network_options = array();
-
-	/**
 	 * Taxonomies with archive pages, which can have meta fields set for them.
 	 *
 	 * @see  WP_SEO_Settings::setup().
@@ -72,8 +65,6 @@ class WP_SEO_Settings {
 	private $archived_post_types = array();
 
 	const SLUG = 'wp-seo';
-
-	const NETWORK_SLUG = 'wp-seo-network';
 
 	/**
 	 * Unused.
@@ -127,8 +118,7 @@ class WP_SEO_Settings {
 			add_action( 'admin_menu', array( $this, 'add_options_page' ) );
 			add_action( 'admin_init', array( $this, 'register_settings' ) );
 			add_action( 'load-settings_page_' . $this::SLUG, array( $this, 'add_help_tab' ) );
-			add_action( 'network_admin_menu', array( $this, 'add_network_options_page' ) );
-			add_action( 'network_admin_edit_wp-seo-network', array( $this, 'save_network_settings' ) );
+
 		}
 	}
 
@@ -194,27 +184,6 @@ class WP_SEO_Settings {
 			$this->set_options();
 		}
 		return isset( $this->options[ $key ] ) ? $this->options[ $key ] : $default;
-	}
-
-	/**
-	 * Set $network_options with the current network database value.
-	 */
-	public function set_network_options() {
-		$this->network_options = get_site_option( $this::NETWORK_SLUG, array() );
-	}
-
-	/**
-	 * Get a network option value.
-	 *
-	 * @param string $key     The option key sought.
-	 * @param mixed  $default Optional default.
-	 * @return mixed The value, or null on failure.
-	 */
-	public function get_network_option( $key, $default = null ) {
-		if ( empty( $this->network_options ) ) {
-			$this->set_network_options();
-		}
-		return isset( $this->network_options[ $key ] ) ? $this->network_options[ $key ] : $default;
 	}
 
 	/**
@@ -287,74 +256,6 @@ class WP_SEO_Settings {
 	 */
 	public function add_options_page() {
 		add_options_page( __( 'WP SEO Settings', 'wp-seo' ), __( 'SEO', 'wp-seo' ), $this->options_capability, $this::SLUG, array( $this, 'view_settings_page' ) );
-	}
-
-	/**
-	 * Register the plugin network options page.
-	 */
-	public function add_network_options_page() {
-		add_submenu_page( 'settings.php', __( 'WP SEO Settings', 'wp-seo' ), __( 'SEO', 'wp-seo' ), 'manage_network_options', $this::SLUG, array( $this, 'view_network_settings_page' ) );
-	}
-
-	/**
-	 * Render the network settings page for robots.txt network prefix/suffix fields.
-	 */
-	public function view_network_settings_page() {
-		?>
-		<div class="wrap" id="wp_seo_network_settings">
-			<h2><?php esc_html_e( 'WP SEO Network Settings', 'wp-seo' ); ?></h2>
-			<?php if ( filter_input( INPUT_GET, 'updated' ) ) : ?>
-				<div class="notice notice-success is-dismissible"><p><?php esc_html_e( 'Network settings saved.', 'wp-seo' ); ?></p></div>
-			<?php endif; ?>
-			<form action="edit.php?action=wp-seo-network" method="POST">
-				<?php wp_nonce_field( 'wp-seo-network-options' ); ?>
-				<?php
-				/** This filter is documented in php/class-wp-seo-settings.php */
-				if ( apply_filters( 'wp_seo_use_settings_accordions', true ) ) {
-					global $wp_settings_sections;
-					foreach ( (array) $wp_settings_sections[ $this::NETWORK_SLUG ] as $section ) {
-						add_meta_box( $section['id'], $section['title'], array( $this, 'settings_meta_box' ), $this::NETWORK_SLUG, 'advanced', 'default', array_merge( $section, array( 'slug' => $this::NETWORK_SLUG ) ) );
-					}
-					do_accordion_sections( $this::NETWORK_SLUG, 'advanced', null );
-				} else {
-					do_settings_sections( $this::NETWORK_SLUG );
-				}
-				?>
-				<?php submit_button(); ?>
-			</form>
-		</div>
-		<?php
-	}
-
-	/**
-	 * Handle saving the network robots.txt settings.
-	 *
-	 * Double-gated: only processes when the request originates from the network
-	 * admin (via the network_admin_edit_wp-seo-network action) and the current
-	 * user has manage_network_options. This prevents network settings from being
-	 * updated via the regular per-site settings form, even by users who hold
-	 * network admin credentials.
-	 */
-	public function save_network_settings() {
-		check_admin_referer( 'wp-seo-network-options' );
-
-		if ( ! is_network_admin() || ! current_user_can( 'manage_network_options' ) ) {
-			wp_die( esc_html__( 'You do not have permission to perform this action.', 'wp-seo' ) );
-		}
-
-		$in = isset( $_POST[ $this::SLUG ] ) && is_array( $_POST[ $this::SLUG ] ) ? $_POST[ $this::SLUG ] : array();
-
-		if ( empty( $this->network_options ) ) {
-			$this->set_network_options();
-		}
-
-		$this->network_options['robots_txt_network_prefix'] = isset( $in['robots_txt_network_prefix'] ) && is_string( $in['robots_txt_network_prefix'] ) ? sanitize_text_field( $in['robots_txt_network_prefix'] ) : '';
-		$this->network_options['robots_txt_network_suffix'] = isset( $in['robots_txt_network_suffix'] ) && is_string( $in['robots_txt_network_suffix'] ) ? sanitize_text_field( $in['robots_txt_network_suffix'] ) : '';
-
-		update_site_option( $this::NETWORK_SLUG, $this->network_options );
-
-		wp_safe_redirect( add_query_arg( array( 'page' => $this::SLUG, 'updated' => 'true' ), network_admin_url( 'settings.php' ) ) );
-		exit;
 	}
 
 	/**
@@ -434,12 +335,6 @@ class WP_SEO_Settings {
 		add_settings_field( 'robots_txt_prefix', __( 'Add to start of Robots.txt', 'wp-seo' ), array( $this, 'field' ), $this::SLUG, 'robots', array( 'type' => 'textarea', 'field' => 'robots_txt_prefix' ) );
 		add_settings_field( 'robots_txt_suffix', __( 'Add to end of Robots.txt', 'wp-seo' ), array( $this, 'field' ), $this::SLUG, 'robots', array( 'type' => 'textarea', 'field' => 'robots_txt_suffix' ) );
 
-		if ( is_network_admin() ) {
-			add_settings_section( 'robots', __( 'Robots.txt', 'wp-seo' ), false, $this::NETWORK_SLUG );
-			add_settings_field( 'robots_example', __( 'Robots.txt Example', 'wp-seo' ), array( $this, 'example_robots_txt' ), $this::NETWORK_SLUG, 'robots' );
-			add_settings_field( 'robots_txt_network_prefix', __( 'Add to start of Robots.txt (Network)', 'wp-seo' ), array( $this, 'field_network' ), $this::NETWORK_SLUG, 'robots', array( 'type' => 'textarea', 'field' => 'robots_txt_network_prefix' ) );
-			add_settings_field( 'robots_txt_network_suffix', __( 'Add to end of Robots.txt (Network)', 'wp-seo' ), array( $this, 'field_network' ), $this::NETWORK_SLUG, 'robots', array( 'type' => 'textarea', 'field' => 'robots_txt_network_suffix' ) );
-		}
 	}
 
 	/**
@@ -581,34 +476,6 @@ class WP_SEO_Settings {
 	 * }
 	 */
 	public function field( $args ) {
-		$this->render_field( $args, array( $this, 'get_option' ) );
-	}
-
-	/**
-	 * Display a network settings field.
-	 *
-	 * @param array $args Field arguments. @see render_field().
-	 */
-	public function field_network( $args ) {
-		$this->render_field( $args, array( $this, 'get_network_option' ) );
-	}
-
-	/**
-	 * Render a settings field using the provided getter callable.
-	 *
-	 * Shared implementation for field() and field_network(). Callers pass the
-	 * appropriate getter (get_option or get_network_option) so lazy-loading and
-	 * value lookup are handled by the getter regardless of storage source.
-	 *
-	 * @param array    $args   {
-	 *     Field arguments.
-	 *
-	 *     @type string $field The option key to pass to $getter.
-	 *     @type string $type  Optional field type. Defaults to 'text'.
-	 * }
-	 * @param callable $getter Callable that accepts ( $key, $default ) and returns the value.
-	 */
-	protected function render_field( $args, callable $getter ) {
 		if ( empty( $args['field'] ) ) {
 			return;
 		}
@@ -617,7 +484,7 @@ class WP_SEO_Settings {
 			$args['type'] = 'text';
 		}
 
-		$value = call_user_func( $getter, $args['field'], '' );
+		$value = ! empty( $this->options[ $args['field'] ] ) ? $this->options[ $args['field'] ] : '';
 
 		switch ( $args['type'] ) {
 			case 'textarea' :
@@ -844,7 +711,7 @@ class WP_SEO_Settings {
 					if ( apply_filters( 'wp_seo_use_settings_accordions', true ) ) {
 						global $wp_settings_sections;
 						foreach ( (array) $wp_settings_sections[ $this::SLUG ] as $section ) {
-							add_meta_box( $section['id'], $section['title'], array( $this, 'settings_meta_box' ), $this::SLUG, 'advanced', 'default', array_merge( $section, array( 'slug' => $this::SLUG ) ) );
+							add_meta_box( $section['id'], $section['title'], array( $this, 'settings_meta_box' ), $this::SLUG, 'advanced', 'default', $section );
 						}
 						do_accordion_sections( $this::SLUG, 'advanced', null );
 					} else {
@@ -860,27 +727,23 @@ class WP_SEO_Settings {
 	/**
 	 * Render a section's fields as a meta box.
 	 *
-	 * @param mixed $_object Unused. Data passed from do_accordion_sections().
-	 * @param array $box {
+	 * @param  mixed $object Unused. Data passed from do_accordion_sections().
+	 * @param  array $box {
 	 *     An array of meta box arguments.
 	 *
-	 *     @type string   $id       @see add_meta_box().
-	 *     @type string   $title    @see add_meta_box().
-	 *     @type callback $callback @see add_meta_box().
-	 *     @type array    $args     @see add_meta_box(), add_settings_section().
-	 *           @type string $slug The settings page slug to pass to do_settings_fields().
-	 *                              Defaults to SLUG.
+	 *     @type  string $id @see add_meta_box().
+	 *     @type  string $title @see add_meta_box().
+	 *     @type  callback $callback @see add_meta_box().
+	 *     @type  array $args @see add_meta_box(), add_settings_section().
 	 * }
 	 */
-	public function settings_meta_box( $_object, $box ) {
+	public function settings_meta_box( $object, $box ) {
 		if ( is_callable( $box['args']['callback'] ) ) {
 			call_user_func( $box['args']['callback'], $box['args'] );
 		}
 
-		$slug = isset( $box['args']['slug'] ) ? $box['args']['slug'] : $this::SLUG;
-
 		echo '<table class="form-table">';
-		do_settings_fields( $slug, $box['args']['id'] );
+		do_settings_fields( $this::SLUG, $box['args']['id'] );
 		echo '</table>';
 	}
 

--- a/php/class-wp-seo-settings.php
+++ b/php/class-wp-seo-settings.php
@@ -313,7 +313,7 @@ class WP_SEO_Settings {
 				if ( apply_filters( 'wp_seo_use_settings_accordions', true ) ) {
 					global $wp_settings_sections;
 					foreach ( (array) $wp_settings_sections[ $this::NETWORK_SLUG ] as $section ) {
-						add_meta_box( $section['id'], $section['title'], array( $this, 'network_settings_meta_box' ), $this::NETWORK_SLUG, 'advanced', 'default', $section );
+						add_meta_box( $section['id'], $section['title'], array( $this, 'settings_meta_box' ), $this::NETWORK_SLUG, 'advanced', 'default', array_merge( $section, array( 'slug' => $this::NETWORK_SLUG ) ) );
 					}
 					do_accordion_sections( $this::NETWORK_SLUG, 'advanced', null );
 				} else {
@@ -844,7 +844,7 @@ class WP_SEO_Settings {
 					if ( apply_filters( 'wp_seo_use_settings_accordions', true ) ) {
 						global $wp_settings_sections;
 						foreach ( (array) $wp_settings_sections[ $this::SLUG ] as $section ) {
-							add_meta_box( $section['id'], $section['title'], array( $this, 'settings_meta_box' ), 'wp-seo', 'advanced', 'default', $section );
+							add_meta_box( $section['id'], $section['title'], array( $this, 'settings_meta_box' ), 'wp-seo', 'advanced', 'default', array_merge( $section, array( 'slug' => $this::SLUG ) ) );
 						}
 						do_accordion_sections( 'wp-seo', 'advanced', null );
 					} else {
@@ -870,32 +870,30 @@ class WP_SEO_Settings {
 	 *     @type  array $args @see add_meta_box(), add_settings_section().
 	 * }
 	 */
-	public function settings_meta_box( $object, $box ) {
-		if ( is_callable( $box['args']['callback'] ) ) {
-			call_user_func( $box['args']['callback'], $box['args'] );
-		}
-
-		echo '<table class="form-table">';
-		do_settings_fields( $this::SLUG, $box['args']['id'] );
-		echo '</table>';
-	}
-
 	/**
-	 * Render a network settings section's fields as a meta box.
+	 * Render a section's fields as a meta box.
 	 *
-	 * Mirrors settings_meta_box(), but uses NETWORK_SLUG so do_settings_fields()
-	 * pulls from the network-registered fields rather than the site fields.
+	 * @param mixed $_object Unused. Data passed from do_accordion_sections().
+	 * @param array $box {
+	 *     An array of meta box arguments.
 	 *
-	 * @param mixed $object Unused.
-	 * @param array $box    @see settings_meta_box().
+	 *     @type string   $id       @see add_meta_box().
+	 *     @type string   $title    @see add_meta_box().
+	 *     @type callback $callback @see add_meta_box().
+	 *     @type array    $args     @see add_meta_box(), add_settings_section().
+	 *           @type string $slug The settings page slug to pass to do_settings_fields().
+	 *                              Defaults to SLUG.
+	 * }
 	 */
-	public function network_settings_meta_box( $_object, $box ) {
+	public function settings_meta_box( $_object, $box ) {
 		if ( is_callable( $box['args']['callback'] ) ) {
 			call_user_func( $box['args']['callback'], $box['args'] );
 		}
 
+		$slug = isset( $box['args']['slug'] ) ? $box['args']['slug'] : $this::SLUG;
+
 		echo '<table class="form-table">';
-		do_settings_fields( $this::NETWORK_SLUG, $box['args']['id'] );
+		do_settings_fields( $slug, $box['args']['id'] );
 		echo '</table>';
 	}
 

--- a/php/class-wp-seo.php
+++ b/php/class-wp-seo.php
@@ -653,7 +653,7 @@ if ( ! class_exists( 'WP_SEO' ) ) :
 			 */
 			$robots_suffix = apply_filters( 'wp_seo_robots_txt_suffix', WP_SEO_Settings()->get_option( 'robots_txt_suffix', '' ) );
 
-			return $robots_network_prefix . $robots_prefix . $robots . $robots_suffix . $robots_network_suffix;
+			return $robots_network_prefix . PHP_EOL . $robots_prefix . PHP_EOL . $robots . PHP_EOL . $robots_suffix . PHP_EOL . $robots_network_suffix;
 		}
 	}
 

--- a/php/class-wp-seo.php
+++ b/php/class-wp-seo.php
@@ -90,6 +90,7 @@ if ( ! class_exists( 'WP_SEO' ) ) :
 			add_filter( 'pre_get_document_title', array( $this, 'pre_get_document_title' ), 20 );
 			add_filter( 'wp_title', array( $this, 'wp_title' ), 20, 2 );
 			add_filter( 'wp_head', array( $this, 'wp_head' ), 5 );
+			add_filter( 'robots_txt', array( $this, 'robots_txt' ) );
 		}
 
 		/**
@@ -615,6 +616,18 @@ if ( ! class_exists( 'WP_SEO' ) ) :
 				}
 			}
 
+		}
+
+		/**
+		 * Build the prefix and suffix for the Robots.txt file, and return it.
+		 *
+		 * @param string $robots The robots.txt file contents.
+		 * @return string
+		 */
+		public function robots_txt( string $robots ): string {
+			$robots_prefix = apply_filters( 'wp_seo_robots_txt_prefix', WP_SEO_Settings()->get_option( 'robots_txt_prefix', '' ) );
+			$robots_suffix = apply_filters( 'wp_seo_robots_txt_suffix', WP_SEO_Settings()->get_option( 'robots_txt_suffix', '' ) );
+			return $robots_prefix . $robots . $robots_suffix;
 		}
 	}
 

--- a/php/class-wp-seo.php
+++ b/php/class-wp-seo.php
@@ -653,7 +653,18 @@ if ( ! class_exists( 'WP_SEO' ) ) :
 			 */
 			$robots_suffix = apply_filters( 'wp_seo_robots_txt_suffix', WP_SEO_Settings()->get_option( 'robots_txt_suffix', '' ) );
 
-			return $robots_network_prefix . PHP_EOL . $robots_prefix . PHP_EOL . $robots . PHP_EOL . $robots_suffix . PHP_EOL . $robots_network_suffix;
+			return implode(
+				PHP_EOL,
+				array_filter(
+					array(
+						$robots_network_prefix,
+						$robots_prefix,
+						$robots,
+						$robots_suffix,
+						$robots_network_suffix
+					)
+				)
+			);
 		}
 	}
 

--- a/php/class-wp-seo.php
+++ b/php/class-wp-seo.php
@@ -626,20 +626,6 @@ if ( ! class_exists( 'WP_SEO' ) ) :
 		 */
 		public function robots_txt( string $robots ): string {
 			/**
-			 * Filters the network-level Robots.txt Prefix value for WP SEO.
-			 *
-			 * @param string $prefix The robots.txt network prefix, added in the WP SEO network settings page.
-			 */
-			$robots_network_prefix = apply_filters( 'wp_seo_robots_txt_network_prefix', WP_SEO_Settings()->get_network_option( 'robots_txt_network_prefix', '' ) );
-
-			/**
-			 * Filters the network-level Robots.txt Suffix value for WP SEO.
-			 *
-			 * @param string $suffix The robots.txt network suffix, added in the WP SEO network settings page.
-			 */
-			$robots_network_suffix = apply_filters( 'wp_seo_robots_txt_network_suffix', WP_SEO_Settings()->get_network_option( 'robots_txt_network_suffix', '' ) );
-
-			/**
 			 * Filters the Robots.txt Prefix value for WP SEO.
 			 *
 			 * @param string $prefix The robots.txt prefix, added in the WP SEO settings page.
@@ -653,18 +639,7 @@ if ( ! class_exists( 'WP_SEO' ) ) :
 			 */
 			$robots_suffix = apply_filters( 'wp_seo_robots_txt_suffix', WP_SEO_Settings()->get_option( 'robots_txt_suffix', '' ) );
 
-			return implode(
-				PHP_EOL,
-				array_filter(
-					array(
-						$robots_network_prefix,
-						$robots_prefix,
-						$robots,
-						$robots_suffix,
-						$robots_network_suffix
-					)
-				)
-			);
+			return implode( PHP_EOL, array_filter( array( $robots_prefix, $robots, $robots_suffix ) ) );
 		}
 	}
 

--- a/php/class-wp-seo.php
+++ b/php/class-wp-seo.php
@@ -625,8 +625,20 @@ if ( ! class_exists( 'WP_SEO' ) ) :
 		 * @return string
 		 */
 		public function robots_txt( string $robots ): string {
+			/**
+			 * Filters the Robots.txt Prefix value for WP SEO.
+			 *
+			 * @param string $prefix The robots.txt prefix, added in the WP SEO settings page.
+			 */
 			$robots_prefix = apply_filters( 'wp_seo_robots_txt_prefix', WP_SEO_Settings()->get_option( 'robots_txt_prefix', '' ) );
+
+			/**
+			 * Filters the Robots.txt Suffix value for WP SEO.
+			 *
+			 * @param string $suffix The robots.txt suffix, added in the WP SEO settings page.
+			 */
 			$robots_suffix = apply_filters( 'wp_seo_robots_txt_suffix', WP_SEO_Settings()->get_option( 'robots_txt_suffix', '' ) );
+
 			return $robots_prefix . $robots . $robots_suffix;
 		}
 	}

--- a/php/class-wp-seo.php
+++ b/php/class-wp-seo.php
@@ -626,6 +626,20 @@ if ( ! class_exists( 'WP_SEO' ) ) :
 		 */
 		public function robots_txt( string $robots ): string {
 			/**
+			 * Filters the network-level Robots.txt Prefix value for WP SEO.
+			 *
+			 * @param string $prefix The robots.txt network prefix, added in the WP SEO network settings page.
+			 */
+			$robots_network_prefix = apply_filters( 'wp_seo_robots_txt_network_prefix', WP_SEO_Settings()->get_network_option( 'robots_txt_network_prefix', '' ) );
+
+			/**
+			 * Filters the network-level Robots.txt Suffix value for WP SEO.
+			 *
+			 * @param string $suffix The robots.txt network suffix, added in the WP SEO network settings page.
+			 */
+			$robots_network_suffix = apply_filters( 'wp_seo_robots_txt_network_suffix', WP_SEO_Settings()->get_network_option( 'robots_txt_network_suffix', '' ) );
+
+			/**
 			 * Filters the Robots.txt Prefix value for WP SEO.
 			 *
 			 * @param string $prefix The robots.txt prefix, added in the WP SEO settings page.
@@ -639,7 +653,7 @@ if ( ! class_exists( 'WP_SEO' ) ) :
 			 */
 			$robots_suffix = apply_filters( 'wp_seo_robots_txt_suffix', WP_SEO_Settings()->get_option( 'robots_txt_suffix', '' ) );
 
-			return $robots_prefix . $robots . $robots_suffix;
+			return $robots_network_prefix . $robots_prefix . $robots . $robots_suffix . $robots_network_suffix;
 		}
 	}
 


### PR DESCRIPTION
## Summary

Fixes #167

This pull request adds the ability for administrators to manage and customize the site's robots.txt output directly from the WordPress admin interface. The update introduces both site-level and network-level (for multisite installations) settings for robots.txt, allowing custom directives to be added without requiring file system access. The plugin leverages the `robots_txt` filter to append or prepend custom content, and all logic is encapsulated to ensure compatibility with other plugins and WordPress core.

## Context

Previously, modifying robots.txt required direct file access or code changes, which was not possible in certain hosting environments (e.g., VIP, Pantheon). This update empowers both site and network administrators to manage robots.txt rules through the admin UI, without interfering with existing `robots_txt` filter usage from the core or other plugins.

## Features

- **Robots.txt Settings Section:**  
  A new "Robots.txt" section is available in the SEO settings page for single sites and on the network settings page for multisite installations.
- **Live Preview:**  
  Admins can view a live preview of the compiled robots.txt output before saving changes.
- **Custom Entry Fields:**  
  Separate fields for adding custom directives at both the site and network level.
- **Multisite Support:**  
  Network administrators can set global rules, which are combined with individual site rules for the final output.
- **Filter Implementation:**  
  Uses the `robots_txt` filter to dynamically update the robots.txt output based on saved settings.
- **Refactored & Commented Code:**  
  Includes code clean-up, consolidated meta box logic, improved maintainability, and updated hardcoded values for consistency.

## Use Case

Admins can now quickly adjust robots.txt content from the WordPress dashboard, streamlining SEO management and compliance with search engine guidelines—no code or file uploads required.

## Checklist

- [ ] I have tested these changes locally.
- [ ] I have updated the documentation as needed.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have assigned reviewers to this pull request.