### PR TITLE
updates meta keys with alley_seo prefix

### DIFF
--- a/components/open-graph/index.tsx
+++ b/components/open-graph/index.tsx
@@ -149,9 +149,9 @@ function OpenGraphSlotfill() {
   const currentPostType = select('core/editor').getCurrentPostType();
   const postType = select('core').getEntityRecord('root', 'postType', currentPostType);
 
-  const [title, setTitle] = usePostMetaValue('wp_seo_open_graph_title');
-  const [description, setDescription] = usePostMetaValue('wp_seo_open_graph_description');
-  const [image, setImage] = usePostMetaValue('wp_seo_open_graph_image');
+  const [title, setTitle] = usePostMetaValue('alley_seo_open_graph_title');
+  const [description, setDescription] = usePostMetaValue('alley_seo_open_graph_description');
+  const [image, setImage] = usePostMetaValue('alley_seo_open_graph_image');
   const [showModal, setShowModal] = useState(false);
 
   const selectedImage = useMedia(image);

--- a/components/search-engine/index.tsx
+++ b/components/search-engine/index.tsx
@@ -10,8 +10,8 @@ import {
 } from '@alleyinteractive/block-editor-tools';
 
 function SearchEngineSlotfill() {
-  const [title, setTitle] = usePostMetaValue('search_engine_title');
-  const [description, setDescription] = usePostMetaValue('search_engine_description');
+  const [title, setTitle] = usePostMetaValue('alley_seo_search_engine_title');
+  const [description, setDescription] = usePostMetaValue('alley_seo_search_engine_description');
 
   return (
     <PanelBody

--- a/config/post-meta.json
+++ b/config/post-meta.json
@@ -1,12 +1,12 @@
 {
-  "search_engine_title": {
+  "alley_seo_search_engine_title": {
     "default": "",
     "post_types": [
       "page",
       "post"
     ]
   },
-  "search_engine_description": {
+  "alley_seo_search_engine_description": {
     "default": "",
     "post_types": [
       "page",

--- a/php/admin-functions.php
+++ b/php/admin-functions.php
@@ -25,7 +25,7 @@ function wp_seo_get_box_title() {
  * @param int $post_id Post ID.
  */
 function wp_seo_post_id_to_the_meta_title_input( $post_id ) {
-	wp_seo_the_meta_title_input( get_post_meta( $post_id, '_meta_title', true ) );
+	wp_seo_the_meta_title_input( get_post_meta( $post_id, '_alley_seo_meta_title', true ) );
 }
 
 /**
@@ -34,7 +34,7 @@ function wp_seo_post_id_to_the_meta_title_input( $post_id ) {
  * @param int $post_id Post ID.
  */
 function wp_seo_post_id_to_the_title_character_count( $post_id ) {
-	wp_seo_the_title_character_count( strlen( get_post_meta( $post_id, '_meta_title', true ) ) );
+	wp_seo_the_title_character_count( strlen( get_post_meta( $post_id, '_alley_seo_meta_title', true ) ) );
 }
 
 /**
@@ -43,7 +43,7 @@ function wp_seo_post_id_to_the_title_character_count( $post_id ) {
  * @param int $post_id Post ID.
  */
 function wp_seo_post_id_to_the_meta_description_input( $post_id ) {
-	wp_seo_the_meta_description_input( get_post_meta( $post_id, '_meta_description', true ) );
+	wp_seo_the_meta_description_input( get_post_meta( $post_id, '_alley_seo_meta_description', true ) );
 }
 
 /**
@@ -52,7 +52,7 @@ function wp_seo_post_id_to_the_meta_description_input( $post_id ) {
  * @param int $post_id Post ID.
  */
 function wp_seo_post_id_to_the_description_character_count( $post_id ) {
-	wp_seo_the_description_character_count( strlen( get_post_meta( $post_id, '_meta_description', true ) ) );
+	wp_seo_the_description_character_count( strlen( get_post_meta( $post_id, '_alley_seo_meta_description', true ) ) );
 }
 
 /**
@@ -61,7 +61,7 @@ function wp_seo_post_id_to_the_description_character_count( $post_id ) {
  * @param int $post_id Post ID.
  */
 function wp_seo_post_id_to_the_meta_canonical_url_input( $post_id ) {
-	wp_seo_the_meta_canonical_url_input( get_post_meta( $post_id, '_meta_canonical_url', true ) );
+	wp_seo_the_meta_canonical_url_input( get_post_meta( $post_id, '_alley_seo_meta_canonical_url', true ) );
 }
 
 /**
@@ -71,7 +71,7 @@ function wp_seo_post_id_to_the_meta_canonical_url_input( $post_id ) {
  * @param string $directive Robots directive key (e.g., 'noindex').
  */
 function wp_seo_post_id_to_the_meta_robots_input( $post_id, $directive ) {
-	wp_seo_the_meta_robots_input( get_post_meta( $post_id, '_meta_robots_' . $directive, true ), $directive );
+	wp_seo_the_meta_robots_input( get_post_meta( $post_id, '_alley_seo_meta_robots_' . $directive, true ), $directive );
 }
 
 /**

--- a/php/class-wp-seo.php
+++ b/php/class-wp-seo.php
@@ -260,7 +260,7 @@ if ( ! class_exists( 'WP_SEO' ) ) :
 				)
 			);
 			foreach ( $fields as $field ) {
-				$meta_key = wp_slash( '_meta_' . $field );
+				$meta_key = wp_slash( '_alley_seo_meta_' . $field );
 
 				// If this is the canonical URL field, validate it as a URL.
 				if ( 'canonical_url' === $field ) {
@@ -481,7 +481,7 @@ if ( ! class_exists( 'WP_SEO' ) ) :
 		 */
 		public function wp_title( $title, $sep ) {
 			if ( is_singular() ) {
-				if ( WP_SEO_Settings()->has_post_fields( $post_type = get_post_type() ) && $meta_title = get_post_meta( get_the_ID(), '_meta_title', true ) ) {
+				if ( WP_SEO_Settings()->has_post_fields( $post_type = get_post_type() ) && $meta_title = get_post_meta( get_the_ID(), '_alley_seo_meta_title', true ) ) {
 					return $meta_title;
 				} else {
 					$key = "single_{$post_type}_title";
@@ -616,8 +616,8 @@ if ( ! class_exists( 'WP_SEO' ) ) :
 			if ( is_singular() ) {
 				if ( WP_SEO_Settings()->has_post_fields( $post_type = get_post_type() ) ) {
 					$post_id          = get_the_ID();
-					$meta_description = get_post_meta( $post_id, '_meta_description', true );
-					$canonical_url    = get_post_meta( $post_id, '_meta_canonical_url', true );
+					$meta_description = get_post_meta( $post_id, '_alley_seo_meta_description', true );
+					$canonical_url    = get_post_meta( $post_id, '_alley_seo_meta_canonical_url', true );
 				}
 				$key = "single_{$post_type}";
 			} elseif ( is_front_page() ) {
@@ -835,8 +835,8 @@ if ( ! class_exists( 'WP_SEO' ) ) :
 
 				// Allow the directive value to be overridden on the post and term level.
 				if ( ! empty( $object_data ) ) {
-					if ( is_singular() && ! empty( $object_data[ "_meta_robots_{$directive}" ][0] ) ) {
-						$robots_meta = $object_data[ "_meta_robots_{$directive}" ][0];
+					if ( is_singular() && ! empty( $object_data[ "_alley_seo_meta_robots_{$directive}" ][0] ) ) {
+						$robots_meta = $object_data[ "_alley_seo_meta_robots_{$directive}" ][0];
 					} elseif ( ( is_category() || is_tag() || is_tax() ) && ! empty( $object_data[ "robots_{$directive}" ] ) ) {
 						$robots_meta = $object_data[ "robots_{$directive}" ];
 					}

--- a/src/features/class-open-graph.php
+++ b/src/features/class-open-graph.php
@@ -58,7 +58,7 @@ final class Open_Graph implements Feature {
 		register_meta_helper(
 			'post',
 			get_post_types_by_support( 'open-graph' ),
-			'wp_seo_open_graph_title',
+			'alley_seo_open_graph_title',
 			[
 				'sanitize_callback' => 'sanitize_text_field',
 				'single'            => true,
@@ -70,7 +70,7 @@ final class Open_Graph implements Feature {
 		register_meta_helper(
 			'post',
 			get_post_types_by_support( 'open-graph' ),
-			'wp_seo_open_graph_description',
+			'alley_seo_open_graph_description',
 			[
 				'sanitize_callback' => 'sanitize_text_field',
 				'single'            => true,
@@ -82,7 +82,7 @@ final class Open_Graph implements Feature {
 		register_meta_helper(
 			'post',
 			get_post_types_by_support( 'open-graph' ),
-			'wp_seo_open_graph_image',
+			'alley_seo_open_graph_image',
 			[
 				'sanitize_callback' => 'absint',
 				'single'            => true,
@@ -100,7 +100,7 @@ final class Open_Graph implements Feature {
 	 * @return string The title.
 	 */
 	public static function get_title( $post_id ): string {
-		$open_graph_title = get_post_meta( $post_id, 'wp_seo_open_graph_title', true );
+		$open_graph_title = get_post_meta( $post_id, 'alley_seo_open_graph_title', true );
 
 		if ( ! empty( $open_graph_title ) && is_string( $open_graph_title ) ) {
 			return $open_graph_title;
@@ -117,7 +117,7 @@ final class Open_Graph implements Feature {
 	 * @return string The description.
 	 */
 	public static function get_description( $post_id ): string {
-		$open_graph_description = get_post_meta( $post_id, 'wp_seo_open_graph_description', true );
+		$open_graph_description = get_post_meta( $post_id, 'alley_seo_open_graph_description', true );
 
 		if ( ! empty( $open_graph_description ) && is_string( $open_graph_description ) ) {
 			return $open_graph_description;
@@ -134,7 +134,7 @@ final class Open_Graph implements Feature {
 	 * @return string|false The image URL or false if no assigned images.
 	 */
 	public static function get_image( $post_id ): string|bool {
-		$open_graph_image_id  = get_post_meta( $post_id, 'wp_seo_open_graph_image', true );
+		$open_graph_image_id  = get_post_meta( $post_id, 'alley_seo_open_graph_image', true );
 		$open_graph_image_url = ( ! empty( $open_graph_image_id ) && is_string( $open_graph_image_id ) )
 		? wp_get_attachment_image_url( (int) $open_graph_image_id, 'full' )
 		: false;

--- a/src/features/class-open-graph.php
+++ b/src/features/class-open-graph.php
@@ -170,12 +170,12 @@ final class Open_Graph implements Feature {
 		$description = $this->get_description( $post_id );
 		$image       = $this->get_image( $post_id );
 		$permalink   = ! empty( get_permalink( $post_id ) ) ? get_permalink( $post_id ) : '';
-		$additional = '';
+		$additional  = '';
 
 		// Add article related tags.
 		if ( is_singular() ) {
-			$published_time = get_the_date('c', $post_id);
-			$modified_time  = get_the_modified_date('c', $post_id);
+			$published_time = get_the_date( 'c', $post_id );
+			$modified_time  = get_the_modified_date( 'c', $post_id );
 
 			if ( ! empty( $published_time ) ) {
 				$additional .= sprintf( "\n<meta property=\"article:published_time\" content=\"%s\" />", esc_attr( $published_time ) );
@@ -204,7 +204,7 @@ HTML,
 			esc_attr( $title ),
 			esc_attr( $description ),
 			esc_url( $permalink ),
-			$additional
+			$additional // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- $additional is pre-built HTML with all dynamic values already escaped via esc_attr/esc_url.
 		);
 	}
 }

--- a/tests/Feature/AdminFunctionTest.php
+++ b/tests/Feature/AdminFunctionTest.php
@@ -45,11 +45,11 @@ class AdminFunctionTest extends TestCase {
 
 		$post_id = static::factory()->post->create( [
 			'meta_input' => [
-				'_meta_title'               => $meta_title,
-				'_meta_description'         => $meta_description,
-				'_meta_canonical_url'       => $meta_canonical_url,
-				'_meta_robots_noindex'      => $meta_robots_noindex,
-				'_meta_robots_nofollow'     => $meta_robots_nofollow,
+				'_alley_seo_meta_title'               => $meta_title,
+				'_alley_seo_meta_description'         => $meta_description,
+				'_alley_seo_meta_canonical_url'       => $meta_canonical_url,
+				'_alley_seo_meta_robots_noindex'      => $meta_robots_noindex,
+				'_alley_seo_meta_robots_nofollow'     => $meta_robots_nofollow,
 			],
 		] );
 		do_action( 'admin_init' );

--- a/tests/Feature/MetaboxesTest.php
+++ b/tests/Feature/MetaboxesTest.php
@@ -68,8 +68,8 @@ class MetaboxesTest extends TestCase {
 		$post_ID = $this->factory->post->create();
 		$title = rand_str();
 		$description = rand_str();
-		add_post_meta( $post_ID, '_meta_title', $title );
-		add_post_meta( $post_ID, '_meta_description', $description );
+		add_post_meta( $post_ID, '_alley_seo_meta_title', $title );
+		add_post_meta( $post_ID, '_alley_seo_meta_description', $description );
 
 		$post = get_post( $post_ID );
 		// Capture the output of the function.
@@ -131,8 +131,8 @@ class MetaboxesTest extends TestCase {
 
 		// No SEO data.
 		WP_SEO()->save_post_fields( $post_ID );
-		$this->assertEmpty( get_post_meta( $post_ID, '_meta_title', true ) );
-		$this->assertEmpty( get_post_meta( $post_ID, '_meta_description', true ) );
+		$this->assertEmpty( get_post_meta( $post_ID, '_alley_seo_meta_title', true ) );
+		$this->assertEmpty( get_post_meta( $post_ID, '_alley_seo_meta_description', true ) );
 
 		$title = rand_str();
 		$description = rand_str();
@@ -145,8 +145,8 @@ class MetaboxesTest extends TestCase {
 
 		// Successful save.
 		WP_SEO()->save_post_fields( $post_ID );
-		$this->assertEquals( $title, get_post_meta( $post_ID, '_meta_title', true ) );
-		$this->assertEquals( $description, get_post_meta( $post_ID, '_meta_description', true ) );
+		$this->assertEquals( $title, get_post_meta( $post_ID, '_alley_seo_meta_title', true ) );
+		$this->assertEquals( $description, get_post_meta( $post_ID, '_alley_seo_meta_description', true ) );
 
 		$title = "Is your name O'Reilly?";
 		$description = 'What is Folder\SubFolder\File.txt?';
@@ -158,8 +158,8 @@ class MetaboxesTest extends TestCase {
 		] );
 
 		WP_SEO()->save_post_fields( $post_ID );
-		$this->assertEquals( $title, get_post_meta( $post_ID, '_meta_title', true ) );
-		$this->assertEquals( $description, get_post_meta( $post_ID, '_meta_description', true ) );
+		$this->assertEquals( $title, get_post_meta( $post_ID, '_alley_seo_meta_title', true ) );
+		$this->assertEquals( $description, get_post_meta( $post_ID, '_alley_seo_meta_description', true ) );
 	}
 
 	/**

--- a/tests/Feature/OpenGraphTest.php
+++ b/tests/Feature/OpenGraphTest.php
@@ -23,7 +23,7 @@ class OpenGraphTest extends TestCase {
 		$post_id = $this->factory->post
 		->with_meta(
 			[
-				'wp_seo_open_graph_title' => 'Open Graph Title',
+				'alley_seo_open_graph_title' => 'Open Graph Title',
 			]
 		)
 		->create();
@@ -37,7 +37,7 @@ class OpenGraphTest extends TestCase {
 		$post_id = $this->factory->post
 		->with_meta(
 			[
-				'wp_seo_open_graph_title' => '',
+				'alley_seo_open_graph_title' => '',
 			]
 		)
 		->create(
@@ -55,7 +55,7 @@ class OpenGraphTest extends TestCase {
 		$post_id = $this->factory->post
 		->with_meta(
 			[
-				'wp_seo_open_graph_description' => 'Open Graph Description',
+				'alley_seo_open_graph_description' => 'Open Graph Description',
 			]
 		)
 		->create();
@@ -69,7 +69,7 @@ class OpenGraphTest extends TestCase {
 		$post_id = $this->factory->post
 		->with_meta(
 			[
-				'wp_seo_open_graph_description' => '',
+				'alley_seo_open_graph_description' => '',
 			]
 		)
 		->create(
@@ -102,7 +102,7 @@ class OpenGraphTest extends TestCase {
 		->with_thumbnail()
 		->with_meta(
 			[
-				'wp_seo_open_graph_image' => '',
+				'alley_seo_open_graph_image' => '',
 			]
 		)
 		->create_and_get();
@@ -119,7 +119,7 @@ class OpenGraphTest extends TestCase {
 		$post_id = $this->factory->post
 		->with_meta(
 			[
-				'wp_seo_open_graph_image' => '',
+				'alley_seo_open_graph_image' => '',
 			]
 		)
 		->create();

--- a/tests/Feature/WPTitleWPHeadTest.php
+++ b/tests/Feature/WPTitleWPHeadTest.php
@@ -178,11 +178,11 @@ EOF;
 	// A post with custom values should not use the single_{type}_ values.
 	function test_single_custom() {
 		$this->go_to( get_permalink( $post_ID = $this->factory->post->create() ) );
-		update_post_meta( $post_ID, '_meta_title', '_custom_meta_title' );
-		update_post_meta( $post_ID, '_meta_description', '_custom_meta_description' );
-		update_post_meta( $post_ID, '_canonical_url', '_custom_canonical_url' );
-		update_post_meta( $post_ID, '_robots_noindex', '1' );
-		update_post_meta( $post_ID, '_robots_nofollow', '' );
+		update_post_meta( $post_ID, '_alley_seo_meta_title', '_custom_meta_title' );
+		update_post_meta( $post_ID, '_alley_seo_meta_description', '_custom_meta_description' );
+		update_post_meta( $post_ID, '_alley_seo_meta_canonical_url', '_custom_canonical_url' );
+		update_post_meta( $post_ID, '_alley_seo_meta_robots_noindex', '1' );
+		update_post_meta( $post_ID, '_alley_seo_meta_robots_nofollow', '' );
 		$this->_assert_title( '_custom_meta_title' );
 		$this->_assert_all_meta( '_custom_meta_description', '1', '' );
 		$this->_assert_canonical( '_custom_canonical_url' );

--- a/wp-seo.php
+++ b/wp-seo.php
@@ -90,16 +90,20 @@ require_once WP_SEO_PATH . '/php/default-filters.php';
  */
 function wp_seo_admin_scripts(): void {
 	wp_enqueue_script( 'wp-seo-admin', WP_SEO_URL . 'js/wp-seo.js', [ 'jquery', 'underscore' ], '0.11.1', true );
-	wp_localize_script( 'wp-seo-admin', 'wp_seo_admin', [
-		'repeatable_add_more_label' => __( 'Add another', 'wp-seo' ),
-		'repeatable_remove_label'   => __( 'Remove group', 'wp-seo' ),
-		/**
-		 * Filter the fields that support character counts.
-		 *
-		 * @param array $fields Fields that support character counters.
-		 */
-		'character_count_fields'    => (array) apply_filters( 'wp_seo_character_count_fields', [ 'title', 'description' ] ),
-	] );
+	wp_localize_script(
+		'wp-seo-admin',
+		'wp_seo_admin',
+		[
+			'repeatable_add_more_label' => __( 'Add another', 'wp-seo' ),
+			'repeatable_remove_label'   => __( 'Remove group', 'wp-seo' ),
+			/**
+			 * Filter the fields that support character counts.
+			 *
+			 * @param array $fields Fields that support character counters.
+			 */
+			'character_count_fields'    => (array) apply_filters( 'wp_seo_character_count_fields', [ 'title', 'description' ] ),
+		] 
+	);
 
 	wp_enqueue_style( 'wp-seo-admin', WP_SEO_URL . 'css/wp-seo.css', [], '2.0.0' );
 }


### PR DESCRIPTION
This PR prefixes all custom meta keys to be prefixed with `alley_seo`. Just want to note that a lot of `phpunit` tests are failing. I ran `phpunit` on my branch and the `v2.0` branch to confirm that my PR didn't cause any of them. We also have existing failures in our GH actions tests, mainly updating some Node packages. Unrelated so I didn't address them in this PR, but wanted to raise it.