### PR TITLE
scopes CSS and JS enqueues only to pages that need them

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,5 +6,10 @@
     "license" : "GPL-3.0+",
     "require": {
         "composer/installers": "~1.0"
+    },
+    "config": {
+        "allow-plugins": {
+            "composer/installers": true
+        }
     }
 }

--- a/php/internal-functions.php
+++ b/php/internal-functions.php
@@ -24,3 +24,45 @@ function wp_seo_load_admin_files() {
 function wp_seo_enable_formatting_tag_safe_mode() {
 	add_filter( 'wp_seo_after_format_string', 'wp_seo_no_formatting_tags_allowed' );
 }
+
+/**
+ * Check whether the plugin's admin script and style are needed on the
+ * current admin screen.
+ *
+ * True on the plugin's settings page, on add/edit screens for taxonomies
+ * with SEO fields enabled, and on classic-editor post edit screens for
+ * post types with SEO fields enabled.
+ *
+ * @param string $hook_suffix The current admin page's hook suffix, as
+ *                             passed to the admin_enqueue_scripts action.
+ * @return bool
+ */
+function wp_seo_is_admin_screen_enqueueable( $hook_suffix ) {
+	if ( 'settings_page_' . WP_SEO_Settings::SLUG === $hook_suffix ) {
+		return true;
+	}
+
+	$screen = get_current_screen();
+
+	if ( ! $screen ) {
+		return false;
+	}
+
+	if ( in_array( $hook_suffix, array( 'edit-tags.php', 'term.php' ), true ) ) {
+		return ! empty( $screen->taxonomy ) && WP_SEO_Settings()->has_term_fields( $screen->taxonomy );
+	}
+
+	if ( in_array( $hook_suffix, array( 'post.php', 'post-new.php' ), true ) ) {
+		if ( empty( $screen->post_type ) || ! WP_SEO_Settings()->has_post_fields( $screen->post_type ) ) {
+			return false;
+		}
+
+		if ( function_exists( 'use_block_editor_for_post_type' ) ) {
+			return ! use_block_editor_for_post_type( $screen->post_type );
+		}
+
+		return true;
+	}
+
+	return false;
+}

--- a/tests/test-internal-functions.php
+++ b/tests/test-internal-functions.php
@@ -20,4 +20,76 @@ class WP_SEO_Internal_Functions_Tests extends WP_SEO_Testcase {
 		// After.
 		$this->assertWPError( WP_SEO()->format( $unsafe_string ) );
 	}
+
+	function setUp() {
+		parent::setUp();
+		update_option( WP_SEO_Settings::SLUG, array(
+			'post_types' => array( 'post' ),
+			'taxonomies' => array( 'category' ),
+		) );
+	}
+
+	function tearDown() {
+		parent::tearDown();
+		delete_option( WP_SEO_Settings::SLUG );
+	}
+
+	/**
+	 * Test that the plugin's settings page is always enqueueable.
+	 */
+	function test_is_admin_screen_enqueueable_on_settings_page() {
+		$this->assertTrue( wp_seo_is_admin_screen_enqueueable( 'settings_page_' . WP_SEO_Settings::SLUG ) );
+	}
+
+	/**
+	 * Test taxonomy add/edit screens, only for taxonomies with fields enabled.
+	 */
+	function test_is_admin_screen_enqueueable_on_taxonomy_screens() {
+		set_current_screen( 'edit-tags.php' );
+		get_current_screen()->taxonomy = 'category';
+		$this->assertTrue( wp_seo_is_admin_screen_enqueueable( 'edit-tags.php' ) );
+
+		set_current_screen( 'term.php' );
+		get_current_screen()->taxonomy = 'category';
+		$this->assertTrue( wp_seo_is_admin_screen_enqueueable( 'term.php' ) );
+
+		set_current_screen( 'edit-tags.php' );
+		get_current_screen()->taxonomy = 'post_tag';
+		$this->assertFalse( wp_seo_is_admin_screen_enqueueable( 'edit-tags.php' ) );
+	}
+
+	/**
+	 * Test post edit screens, only for post types with fields enabled and
+	 * only in the classic editor.
+	 */
+	function test_is_admin_screen_enqueueable_on_post_screens() {
+		set_current_screen( 'post.php' );
+		get_current_screen()->post_type = 'page';
+		$this->assertFalse( wp_seo_is_admin_screen_enqueueable( 'post.php' ) );
+
+		set_current_screen( 'post-new.php' );
+		get_current_screen()->post_type = 'post';
+
+		if ( function_exists( 'use_block_editor_for_post_type' ) ) {
+			add_filter( 'use_block_editor_for_post_type', '__return_true' );
+			$this->assertFalse( wp_seo_is_admin_screen_enqueueable( 'post-new.php' ) );
+
+			add_filter( 'use_block_editor_for_post_type', '__return_false' );
+			$this->assertTrue( wp_seo_is_admin_screen_enqueueable( 'post-new.php' ) );
+		} else {
+			$this->assertTrue( wp_seo_is_admin_screen_enqueueable( 'post-new.php' ) );
+		}
+	}
+
+	/**
+	 * Test that unrelated admin screens never get the assets.
+	 */
+	function test_is_admin_screen_enqueueable_on_unrelated_screen() {
+		set_current_screen( 'edit.php' );
+		get_current_screen()->post_type = 'post';
+		$this->assertFalse( wp_seo_is_admin_screen_enqueueable( 'edit.php' ) );
+
+		set_current_screen( 'index.php' );
+		$this->assertFalse( wp_seo_is_admin_screen_enqueueable( 'index.php' ) );
+	}
 }

--- a/wp-seo.php
+++ b/wp-seo.php
@@ -53,8 +53,14 @@ require_once WP_SEO_PATH . '/php/default-filters.php';
 
 /**
  * Enqueues scripts and styles for administration pages.
+ *
+ * @param string $hook_suffix The current admin page's hook suffix.
  */
-function wp_seo_admin_scripts() {
+function wp_seo_admin_scripts( $hook_suffix ) {
+	if ( ! wp_seo_is_admin_screen_enqueueable( $hook_suffix ) ) {
+		return;
+	}
+
 	wp_enqueue_script( 'wp-seo-admin', WP_SEO_URL . 'js/wp-seo.js', array( 'jquery', 'underscore' ), '0.11.1', true );
 	wp_localize_script( 'wp-seo-admin', 'wp_seo_admin', array(
 		'repeatable_add_more_label' => __( 'Add another', 'wp-seo' ),


### PR DESCRIPTION
This PR scopes enqueueing of the plugin's JS and CSS to only pages that need them.