### PR TITLE
3/4 prefix Open Graph meta keys with alley_seo

### DIFF
--- a/components/open-graph/index.tsx
+++ b/components/open-graph/index.tsx
@@ -151,9 +151,9 @@ function OpenGraphSlotfill() {
   const currentPostType = select('core/editor').getCurrentPostType();
   const postType = select('core').getEntityRecord('root', 'postType', currentPostType);
 
-  const [title, setTitle] = usePostMetaValue('wp_seo_open_graph_title');
-  const [description, setDescription] = usePostMetaValue('wp_seo_open_graph_description');
-  const [image, setImage] = usePostMetaValue('wp_seo_open_graph_image');
+  const [title, setTitle] = usePostMetaValue('alley_seo_open_graph_title');
+  const [description, setDescription] = usePostMetaValue('alley_seo_open_graph_description');
+  const [image, setImage] = usePostMetaValue('alley_seo_open_graph_image');
   const [showModal, setShowModal] = useState(false);
 
   const selectedImage = useMedia(image);

--- a/src/features/class-open-graph.php
+++ b/src/features/class-open-graph.php
@@ -50,7 +50,7 @@ final class Open_Graph implements Feature {
 		register_meta_helper(
 			'post',
 			get_post_types_by_support( 'wp-seo-open-graph' ),
-			'wp_seo_open_graph_title',
+			'alley_seo_open_graph_title',
 			[
 				'sanitize_callback' => 'sanitize_text_field',
 				'single'            => true,
@@ -62,7 +62,7 @@ final class Open_Graph implements Feature {
 		register_meta_helper(
 			'post',
 			get_post_types_by_support( 'wp-seo-open-graph' ),
-			'wp_seo_open_graph_description',
+			'alley_seo_open_graph_description',
 			[
 				'sanitize_callback' => 'sanitize_text_field',
 				'single'            => true,
@@ -74,7 +74,7 @@ final class Open_Graph implements Feature {
 		register_meta_helper(
 			'post',
 			get_post_types_by_support( 'wp-seo-open-graph' ),
-			'wp_seo_open_graph_image',
+			'alley_seo_open_graph_image',
 			[
 				'sanitize_callback' => 'absint',
 				'single'            => true,
@@ -92,7 +92,7 @@ final class Open_Graph implements Feature {
 	 * @return string The title.
 	 */
 	public static function get_title( $post_id ): string {
-		$open_graph_title = get_post_meta( $post_id, 'wp_seo_open_graph_title', true );
+		$open_graph_title = get_post_meta( $post_id, 'alley_seo_open_graph_title', true );
 
 		if ( ! empty( $open_graph_title ) && is_string( $open_graph_title ) ) {
 			return $open_graph_title;
@@ -109,7 +109,7 @@ final class Open_Graph implements Feature {
 	 * @return string The description.
 	 */
 	public static function get_description( $post_id ): string {
-		$open_graph_description = get_post_meta( $post_id, 'wp_seo_open_graph_description', true );
+		$open_graph_description = get_post_meta( $post_id, 'alley_seo_open_graph_description', true );
 
 		if ( ! empty( $open_graph_description ) && is_string( $open_graph_description ) ) {
 			return $open_graph_description;
@@ -126,7 +126,7 @@ final class Open_Graph implements Feature {
 	 * @return string|false The image URL or false if no assigned images.
 	 */
 	public static function get_image( $post_id ): string|bool {
-		$open_graph_image_url = wp_seo_get_image_url_from_meta( $post_id, 'wp_seo_open_graph_image' );
+		$open_graph_image_url = wp_seo_get_image_url_from_meta( $post_id, 'alley_seo_open_graph_image' );
 
 		if ( ! empty( $open_graph_image_url ) ) {
 			return $open_graph_image_url;

--- a/tests/Feature/OpenGraphRenderTest.php
+++ b/tests/Feature/OpenGraphRenderTest.php
@@ -93,8 +93,8 @@ class OpenGraphRenderTest extends TestCase {
 		$post_id = $this->factory->post
 			->with_meta(
 				[
-					'wp_seo_open_graph_title'       => 'OG Title',
-					'wp_seo_open_graph_description' => 'OG Description',
+					'alley_seo_open_graph_title'       => 'OG Title',
+					'alley_seo_open_graph_description' => 'OG Description',
 				]
 			)
 			->create();

--- a/tests/Feature/OpenGraphTest.php
+++ b/tests/Feature/OpenGraphTest.php
@@ -23,7 +23,7 @@ class OpenGraphTest extends TestCase {
 		$post_id = $this->factory->post
 		->with_meta(
 			[
-				'wp_seo_open_graph_title' => 'Open Graph Title',
+				'alley_seo_open_graph_title' => 'Open Graph Title',
 			]
 		)
 		->create();
@@ -37,7 +37,7 @@ class OpenGraphTest extends TestCase {
 		$post_id = $this->factory->post
 		->with_meta(
 			[
-				'wp_seo_open_graph_title' => '',
+				'alley_seo_open_graph_title' => '',
 			]
 		)
 		->create(
@@ -55,7 +55,7 @@ class OpenGraphTest extends TestCase {
 		$post_id = $this->factory->post
 		->with_meta(
 			[
-				'wp_seo_open_graph_description' => 'Open Graph Description',
+				'alley_seo_open_graph_description' => 'Open Graph Description',
 			]
 		)
 		->create();
@@ -69,7 +69,7 @@ class OpenGraphTest extends TestCase {
 		$post_id = $this->factory->post
 		->with_meta(
 			[
-				'wp_seo_open_graph_description' => '',
+				'alley_seo_open_graph_description' => '',
 			]
 		)
 		->create(
@@ -102,7 +102,7 @@ class OpenGraphTest extends TestCase {
 		->with_thumbnail()
 		->with_meta(
 			[
-				'wp_seo_open_graph_image' => '',
+				'alley_seo_open_graph_image' => '',
 			]
 		)
 		->create_and_get();
@@ -119,7 +119,7 @@ class OpenGraphTest extends TestCase {
 		$post_id = $this->factory->post
 		->with_meta(
 			[
-				'wp_seo_open_graph_image' => '',
+				'alley_seo_open_graph_image' => '',
 			]
 		)
 		->create();
@@ -171,7 +171,7 @@ class OpenGraphTest extends TestCase {
 		$post_id = $this->factory->post
 		->with_meta(
 			[
-				'wp_seo_open_graph_image' => '',
+				'alley_seo_open_graph_image' => '',
 			]
 		)
 		->create();
@@ -215,7 +215,7 @@ class OpenGraphTest extends TestCase {
 		$post_id = $this->factory->post
 		->with_meta(
 			[
-				'wp_seo_open_graph_image' => '',
+				'alley_seo_open_graph_image' => '',
 			]
 		)
 		->create();
@@ -238,7 +238,7 @@ class OpenGraphTest extends TestCase {
 		$post_id = $this->factory->post
 		->with_meta(
 			[
-				'wp_seo_open_graph_image' => '',
+				'alley_seo_open_graph_image' => '',
 			]
 		)
 		->create();

--- a/tests/Feature/TwitterCardTest.php
+++ b/tests/Feature/TwitterCardTest.php
@@ -56,7 +56,7 @@ class TwitterCardTest extends TestCase {
 		->with_meta(
 			[
 				'wp_seo_twitter_card_title' => '',
-				'wp_seo_open_graph_title'   => 'Open Graph Title',
+				'alley_seo_open_graph_title'   => 'Open Graph Title',
 			]
 		)
 		->create();
@@ -73,7 +73,7 @@ class TwitterCardTest extends TestCase {
 		->with_meta(
 			[
 				'wp_seo_twitter_card_title' => '',
-				'wp_seo_open_graph_title'   => '',
+				'alley_seo_open_graph_title'   => '',
 			]
 		)
 		->create(
@@ -110,7 +110,7 @@ class TwitterCardTest extends TestCase {
 		->with_meta(
 			[
 				'wp_seo_twitter_card_description' => '',
-				'wp_seo_open_graph_description'   => 'Open Graph Description',
+				'alley_seo_open_graph_description'   => 'Open Graph Description',
 			]
 		)
 		->create();
@@ -127,7 +127,7 @@ class TwitterCardTest extends TestCase {
 		->with_meta(
 			[
 				'wp_seo_twitter_card_description' => '',
-				'wp_seo_open_graph_description'   => '',
+				'alley_seo_open_graph_description'   => '',
 			]
 		)
 		->create(
@@ -166,7 +166,7 @@ class TwitterCardTest extends TestCase {
 		->with_meta(
 			[
 				'wp_seo_twitter_card_image' => '',
-				'wp_seo_open_graph_image'   => $attachment_id,
+				'alley_seo_open_graph_image'   => $attachment_id,
 			]
 		)
 		->create();
@@ -187,7 +187,7 @@ class TwitterCardTest extends TestCase {
 		->with_meta(
 			[
 				'wp_seo_twitter_card_image' => '',
-				'wp_seo_open_graph_image'   => '',
+				'alley_seo_open_graph_image'   => '',
 			]
 		)
 		->create_and_get();
@@ -207,7 +207,7 @@ class TwitterCardTest extends TestCase {
 		->with_meta(
 			[
 				'wp_seo_twitter_card_image' => '',
-				'wp_seo_open_graph_image'   => '',
+				'alley_seo_open_graph_image'   => '',
 			]
 		)
 		->create();


### PR DESCRIPTION
Renames the three Open Graph post meta keys from wp_seo_open_graph_* to
alley_seo_open_graph_*, per ADR 0011 and the ruling in #154. Twenty
occurrences across the feature class, the sidebar component, and the two
Open Graph test files.

Open Graph is the only concept renamed in place: it is already a Feature
and already owns its keys. The search_engine_* pair and the legacy _meta_*
keys are deliberately untouched, those keys (and the remaining meta keys) will be converted when the corresponding files/features are migrated over to /src. Supersedes #171.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>